### PR TITLE
Phase 4: Observability, feedback loop, how-to docs, and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,144 @@
-# AI-Powered GitHub Issue Triage
+# GitHub Issue Triage
 
-An AI-powered service that automatically classifies and prioritizes GitHub issues using large language models (LLMs).
+An AI-powered service that automatically classifies, prioritizes, and labels GitHub issues using large language models and retrieval-augmented generation (RAG).
 
-# Overview
+---
 
-Managing GitHub issues can become overwhelming as projects scale. Manual triage is time-consuming and inconsistent, especially in fast-moving teams.
+## Overview
 
-This project introduces an intelligent triage assistant that:
+Managing GitHub issues at scale is time-consuming and inconsistent. This service hooks into GitHub webhooks to triage new issues in real time — no manual review needed for the initial pass.
 
-  - Classifies new issues (bug, feature request, question, documentation, etc.)
-  
-  - Assigns priority levels
-  
-  - Suggests relevant labels
-  
-  - Posts a structured triage summary as a comment
+When a new issue is opened, the service:
 
-The system integrates directly with GitHub using webhooks and processes issues in real time.
+1. Retrieves relevant context from your repository docs and past issues (RAG)
+2. Sends the issue to Claude for classification (falls back to keyword matching if no API key)
+3. Applies labels automatically via the GitHub API
+4. Posts a structured triage summary as a comment
 
-## Key Features (MVP Scope)
+---
 
-  - GitHub webhook integration
+## Features
 
-  - Automated issue classification
+- **Automated classification** — Bug, Feature Request, Documentation, Question, Other
+- **Priority inference** — High, Medium, Low based on content signals
+- **Label management** — Suggests and auto-creates labels, applies them to the issue
+- **RAG context** — Embeds your repository docs and past issues into ChromaDB for richer LLM context
+- **Webhook signature verification** — HMAC-SHA256 validation of all incoming GitHub events
+- **Observability** — Structured logging, in-process metrics endpoint (`GET /metrics`)
+- **Feedback loop** — Maintainers can rate triage accuracy via `POST /feedback`
+- **Graceful degradation** — Every external dependency (LLM, RAG, GitHub API) degrades silently so triage always completes
 
-  - Priority inference
+---
 
-  - Suggested label generation
+## Quick Start
 
-  - Structured triage summary comment
+```bash
+# 1. Clone and install
+git clone https://github.com/hundehanna/Github-Issue-Triage.git
+cd Github-Issue-Triage
+pip install .
 
-## Architecture (High-Level)
+# 2. Configure environment
+cp .env.example .env   # edit with your keys
 
-1. A new GitHub issue is created.
+# 3. Run
+uvicorn app.main:app --reload --port 8000
 
-2. GitHub sends a webhook event to the backend service.
+# 4. Expose via ngrok (for local webhook testing)
+ngrok http 8000
+```
 
-3. The backend extracts issue data (title + description).
+Then configure a GitHub webhook pointing to `https://<your-ngrok-url>/webhooks/github` with event type **Issues**.
 
-4. An LLM analyzes the content and returns structured triage metadata.
+See [docs/how-to.md](docs/how-to.md) for the full setup guide with examples.
 
-5. The service applies labels and posts a triage summary comment.
+---
 
-## Status
+## Example Triage Comment
 
-🚧 Currently in active development (MVP phase).
+When an issue is created, the bot posts:
 
-Planned future improvements include:
+> ## 🤖 Automated Issue Triage
+>
+> | Field | Value |
+> |---|---|
+> | **Category** | 🐛 Bug |
+> | **Priority** | 🔴 High |
+> | **Suggested Labels** | `bug`, `priority-high` |
+>
+> **Reason:** The issue describes a crash on startup with a traceback; blocking keyword indicates high priority.
+>
+> _This triage was performed automatically. A maintainer will review shortly._
 
-  - Duplicate issue detection
+---
 
-  - Team/owner suggestion
+## API Endpoints
 
-  - Confidence scoring
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/health` | Health check |
+| `POST` | `/webhooks/github` | GitHub webhook receiver |
+| `GET` | `/metrics` | Triage metrics (counts, latency, breakdown) |
+| `POST` | `/feedback/{owner}/{repo}/{issue}` | Submit maintainer feedback on triage accuracy |
 
-  - Evaluation and logging framework
+---
 
-## Tech Stack 
+## Environment Variables
 
-  - Python
-  
-  - FastAPI (backend service)
-  
-  - GitHub Webhooks & API
-  
-  - LLM integration (OpenAI / compatible models)
-  
-  - Ngrok (for local webhook testing)
+| Variable | Required | Description |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | No | Enables LLM triage via Claude. Falls back to keyword matching if unset. |
+| `GITHUB_TOKEN` | No | Enables posting comments and applying labels on GitHub. |
+| `GITHUB_WEBHOOK_SECRET` | No | Validates HMAC-SHA256 signatures. Recommended in production. |
+| `LOG_LEVEL` | No | `DEBUG` / `INFO` / `WARNING` / `ERROR` (default: `INFO`) |
+| `LOG_FORMAT` | No | `text` or `json` (default: `text`) |
+| `DOCS_DIR` | No | Path to Markdown docs to ingest into the RAG vector store. |
 
-### Author
+---
 
-Hanna Hunde
-*(Software Engineer | Aspiring AI Engineer)*
+## Architecture
+
+```
+GitHub Repository
+      │
+      ▼ (webhook on issue opened)
+FastAPI Backend  ──► Issue Processor
+                         │
+                         ├── RAG Retrieval (ChromaDB)
+                         ├── LLM Service (Anthropic Claude)
+                         │     └── keyword fallback
+                         ├── GitHub Client (labels + comment)
+                         └── Metrics
+```
+
+---
+
+## Tech Stack
+
+- **Backend**: Python, FastAPI
+- **LLM**: Anthropic Claude (`claude-haiku-4-5`)
+- **RAG**: ChromaDB vector store
+- **GitHub Integration**: Webhooks + REST API via httpx
+- **Testing**: pytest (137 tests)
+
+---
+
+## Running Tests
+
+```bash
+pytest tests/ -v
+```
+
+---
+
+## Documentation
+
+- [How-To Guide](docs/how-to.md) — full setup, examples, and API reference
+- [Project Spec](docs/project_spec.md) — original specification and phase breakdown
+
+---
+
+## Author
+
+**Hanna Hunde**
+*Software Engineer | Aspiring AI Engineer*

--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -1,0 +1,28 @@
+"""Structured logging configuration for the GitHub Issue Triage service."""
+import logging
+import os
+
+
+def configure_logging() -> None:
+    """Configure root logger based on environment.
+
+    Set LOG_LEVEL env var to control verbosity (default: INFO).
+    Set LOG_FORMAT=json for structured JSON output (useful in production).
+    """
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    log_format = os.getenv("LOG_FORMAT", "text").lower()
+
+    if log_format == "json":
+        fmt = (
+            '{"time": "%(asctime)s", "level": "%(levelname)s", '
+            '"logger": "%(name)s", "message": %(message)r}'
+        )
+    else:
+        fmt = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+    logging.basicConfig(
+        level=getattr(logging, log_level, logging.INFO),
+        format=fmt,
+        datefmt="%Y-%m-%dT%H:%M:%S",
+    )
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)

--- a/app/main.py
+++ b/app/main.py
@@ -1,16 +1,26 @@
 import hashlib
 import hmac
+import json
 import logging
+import os
 
 from fastapi import FastAPI, Header, HTTPException, Request
+from pydantic import BaseModel
 
-from app.services.github_client import GitHubClient
+from app.logging_config import configure_logging
+from app.services.github_client import GitHubClient, build_triage_comment
 from app.services.issue_processor import triage_issue
+from app.services.metrics import metrics
 
+configure_logging()
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="GitHub Issue Triage")
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 def _verify_signature(payload_bytes: bytes, signature: str, secret: str) -> bool:
     """Verify GitHub webhook HMAC-SHA256 signature."""
@@ -20,9 +30,52 @@ def _verify_signature(payload_bytes: bytes, signature: str, secret: str) -> bool
     return hmac.compare_digest(expected, signature)
 
 
+def _format_triage_comment(result) -> str:
+    return build_triage_comment(result)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
 @app.get("/health")
 def health():
     return {"status": "ok"}
+
+
+@app.get("/metrics")
+def get_metrics():
+    """Return current in-process triage metrics."""
+    return metrics.to_dict()
+
+
+class FeedbackPayload(BaseModel):
+    verdict: str  # "correct" | "incorrect" | "overridden"
+    note: str = ""
+
+
+@app.post("/feedback/{repo_owner}/{repo_name}/{issue_number}")
+def post_feedback(repo_owner: str, repo_name: str, issue_number: int, body: FeedbackPayload):
+    """Record maintainer feedback on a triage result.
+
+    verdict must be one of: correct, incorrect, overridden
+    """
+    valid = {"correct", "incorrect", "overridden"}
+    if body.verdict not in valid:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid verdict '{body.verdict}'. Must be one of: {', '.join(sorted(valid))}",
+        )
+    repo = f"{repo_owner}/{repo_name}"
+    logger.info(
+        "Feedback received — repo=%s issue=%d verdict=%s note=%r",
+        repo,
+        issue_number,
+        body.verdict,
+        body.note,
+    )
+    metrics.record_feedback(body.verdict)
+    return {"repo": repo, "issue_number": issue_number, "verdict": body.verdict, "recorded": True}
 
 
 @app.post("/webhooks/github")
@@ -31,10 +84,7 @@ async def github_webhook(
     x_github_event: str | None = Header(default=None),
     x_hub_signature_256: str | None = Header(default=None),
 ):
-    import os
-
     webhook_secret = os.getenv("GITHUB_WEBHOOK_SECRET")
-
     raw_body = await request.body()
 
     if webhook_secret:
@@ -50,7 +100,6 @@ async def github_webhook(
         raise HTTPException(status_code=400, detail=f"Unsupported event: {x_github_event}")
 
     try:
-        import json
         payload = json.loads(raw_body)
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid JSON payload")
@@ -97,15 +146,3 @@ async def github_webhook(
         "issue_title": title,
         "triage": triage_result.model_dump(),
     }
-
-
-def _format_triage_comment(result) -> str:
-    labels = ", ".join(f"`{l}`" for l in result.suggested_labels)
-    return (
-        "## Automated Triage Result\n\n"
-        f"**Category**: {result.category}\n"
-        f"**Priority**: {result.priority}\n"
-        f"**Suggested Labels**: {labels}\n"
-        f"**Reason**: {result.reason}\n\n"
-        "_This triage was generated automatically. Maintainers may override these suggestions._"
-    )

--- a/app/services/github_client.py
+++ b/app/services/github_client.py
@@ -2,9 +2,45 @@ import logging
 
 import httpx
 
+from app.models.triage import TriageResult
+
 logger = logging.getLogger(__name__)
 
 GITHUB_API_BASE = "https://api.github.com"
+
+_LABEL_COLORS: dict[str, str] = {
+    "bug": "d73a4a",
+    "feature-request": "a2eeef",
+    "documentation": "0075ca",
+    "question": "d876e3",
+    "other": "e4e669",
+    "priority-high": "b60205",
+    "priority-medium": "fbca04",
+    "priority-low": "0e8a16",
+}
+
+
+def build_triage_comment(result: TriageResult) -> str:
+    """Format a rich triage comment with emojis and a markdown table."""
+    priority_emoji = {"High": "🔴", "Medium": "🟡", "Low": "🟢"}.get(result.priority, "⚪")
+    category_emoji = {
+        "Bug": "🐛",
+        "Feature Request": "✨",
+        "Documentation": "📄",
+        "Question": "❓",
+        "Other": "📌",
+    }.get(result.category, "📌")
+    labels_md = ", ".join(f"`{lbl}`" for lbl in result.suggested_labels)
+    return (
+        "## 🤖 Automated Issue Triage\n\n"
+        "| Field | Value |\n"
+        "|---|---|\n"
+        f"| **Category** | {category_emoji} {result.category} |\n"
+        f"| **Priority** | {priority_emoji} {result.priority} |\n"
+        f"| **Suggested Labels** | {labels_md} |\n\n"
+        f"**Reason:** {result.reason}\n\n"
+        "_This triage was performed automatically. A maintainer will review shortly._"
+    )
 
 
 class GitHubClient:
@@ -33,9 +69,22 @@ class GitHubClient:
         return response.json()
 
     def apply_labels(self, repo: str, issue_number: int, labels: list[str]) -> dict:
-        """Apply labels to an issue. Returns the updated labels list."""
+        """Apply labels to an issue, creating any that don't exist first."""
+        self.ensure_labels_exist(repo, labels)
         url = f"{self._base_url}/repos/{repo}/issues/{issue_number}/labels"
         logger.debug("Applying labels %s to %s#%d", labels, repo, issue_number)
         response = self._client.post(url, json={"labels": labels})
         response.raise_for_status()
         return response.json()
+
+    def ensure_labels_exist(self, repo: str, labels: list[str]) -> None:
+        """Create any labels that don't yet exist in the repository."""
+        url = f"{self._base_url}/repos/{repo}/labels"
+        existing_resp = self._client.get(url, params={"per_page": 100})
+        existing_resp.raise_for_status()
+        existing_names = {lbl["name"] for lbl in existing_resp.json()}
+        for label in labels:
+            if label not in existing_names:
+                color = _LABEL_COLORS.get(label, "ededed")
+                self._client.post(url, json={"name": label, "color": color})
+                logger.debug("Created label '%s' in %s", label, repo)

--- a/app/services/issue_processor.py
+++ b/app/services/issue_processor.py
@@ -3,6 +3,7 @@ import os
 
 from app.models.triage import TriageResult
 from app.services.llm_service import classify_with_llm
+from app.services.metrics import metrics, track_triage_duration
 
 logger = logging.getLogger(__name__)
 
@@ -14,19 +15,31 @@ def triage_issue(repo_name: str, issue_number: int, title: str, body: str) -> Tr
     2. Use the LLM with that context when ANTHROPIC_API_KEY is set.
     3. Fall back to keyword-based heuristics on any error or missing key.
     4. Index the completed triage result for future RAG retrieval.
+    5. Record metrics.
     """
     context = _get_rag_context(title, body)
 
+    used_llm = False
     result: TriageResult | None = None
-    if os.getenv("ANTHROPIC_API_KEY"):
+
+    with track_triage_duration() as timing:
         try:
-            result = classify_with_llm(repo_name, issue_number, title, body, context=context)
+            if os.getenv("ANTHROPIC_API_KEY"):
+                try:
+                    result = classify_with_llm(repo_name, issue_number, title, body, context=context)
+                    used_llm = True
+                except Exception as exc:
+                    logger.warning("LLM triage failed, falling back to keyword matching: %s", exc)
+                    metrics.record_error()
+
+            if result is None:
+                result = _keyword_triage(repo_name, issue_number, title, body)
         except Exception as exc:
-            logger.warning("LLM triage failed, falling back to keyword matching: %s", exc)
+            logger.error("Triage failed entirely for %s#%d: %s", repo_name, issue_number, exc)
+            metrics.record_error()
+            raise
 
-    if result is None:
-        result = _keyword_triage(repo_name, issue_number, title, body)
-
+    metrics.record_triage(result, used_llm=used_llm, latency_ms=timing["latency_ms"])
     _index_result(repo_name, issue_number, title, body, result)
     return result
 

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -1,0 +1,102 @@
+"""In-process metrics for triage observability.
+
+Tracks counts, latency, and category/priority breakdowns in memory.
+Metrics are exposed via GET /metrics and reset on process restart.
+
+Usage:
+    from app.services.metrics import metrics
+    with metrics.track_triage():
+        result = triage_issue(...)
+    metrics.record_triage(result)
+"""
+import logging
+import time
+from collections import defaultdict
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Generator
+
+from app.models.triage import TriageResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TriageMetrics:
+    total: int = 0
+    llm_used: int = 0
+    keyword_fallback: int = 0
+    errors: int = 0
+    category_counts: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    priority_counts: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    feedback_counts: dict[str, int] = field(
+        default_factory=lambda: defaultdict(int)
+    )  # correct / incorrect / overridden
+    total_latency_ms: float = 0.0
+
+    @property
+    def avg_latency_ms(self) -> float:
+        return round(self.total_latency_ms / self.total, 2) if self.total else 0.0
+
+    def record_triage(self, result: TriageResult, *, used_llm: bool, latency_ms: float) -> None:
+        self.total += 1
+        if used_llm:
+            self.llm_used += 1
+        else:
+            self.keyword_fallback += 1
+        self.category_counts[result.category] += 1
+        self.priority_counts[result.priority] += 1
+        self.total_latency_ms += latency_ms
+        logger.info(
+            "Triage metrics — total=%d llm=%d fallback=%d avg_latency_ms=%.1f",
+            self.total,
+            self.llm_used,
+            self.keyword_fallback,
+            self.avg_latency_ms,
+        )
+
+    def record_error(self) -> None:
+        self.errors += 1
+        logger.warning("Triage error recorded — total_errors=%d", self.errors)
+
+    def record_feedback(self, verdict: str) -> None:
+        """Record maintainer feedback. verdict should be 'correct', 'incorrect', or 'overridden'."""
+        self.feedback_counts[verdict] += 1
+        logger.info("Feedback recorded — verdict=%s counts=%s", verdict, dict(self.feedback_counts))
+
+    def to_dict(self) -> dict:
+        return {
+            "total_triaged": self.total,
+            "llm_used": self.llm_used,
+            "keyword_fallback": self.keyword_fallback,
+            "errors": self.errors,
+            "avg_latency_ms": self.avg_latency_ms,
+            "by_category": dict(self.category_counts),
+            "by_priority": dict(self.priority_counts),
+            "feedback": dict(self.feedback_counts),
+        }
+
+    def reset(self) -> None:
+        self.total = 0
+        self.llm_used = 0
+        self.keyword_fallback = 0
+        self.errors = 0
+        self.category_counts = defaultdict(int)
+        self.priority_counts = defaultdict(int)
+        self.feedback_counts = defaultdict(int)
+        self.total_latency_ms = 0.0
+
+
+# Module-level singleton
+metrics = TriageMetrics()
+
+
+@contextmanager
+def track_triage_duration() -> Generator[dict, None, None]:
+    """Context manager that measures elapsed time and stores it in the yielded dict."""
+    info: dict = {}
+    start = time.monotonic()
+    try:
+        yield info
+    finally:
+        info["latency_ms"] = (time.monotonic() - start) * 1000

--- a/docs/how-to.md
+++ b/docs/how-to.md
@@ -1,0 +1,257 @@
+# How to Use — GitHub Issue Triage
+
+This guide explains how to set up, run, and integrate the GitHub Issue Triage service from scratch.
+
+---
+
+## Prerequisites
+
+- Python 3.10+
+- A GitHub repository you own (to configure webhooks)
+- [ngrok](https://ngrok.com/) (for local webhook testing)
+- An Anthropic API key (optional — the service falls back to keyword matching without one)
+- A GitHub Personal Access Token with `repo` scope (optional — required to post comments and apply labels)
+
+---
+
+## 1. Installation
+
+```bash
+git clone https://github.com/hundehanna/Github-Issue-Triage.git
+cd Github-Issue-Triage
+pip install -r requirements.txt   # or: pip install .
+```
+
+---
+
+## 2. Environment Variables
+
+Create a `.env` file in the project root (never commit this):
+
+```env
+# Required for LLM triage (falls back to keywords if not set)
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Required to post comments and apply labels on GitHub issues
+GITHUB_TOKEN=ghp_...
+
+# Required to verify webhook signatures from GitHub
+GITHUB_WEBHOOK_SECRET=your-random-secret
+
+# Optional: logging
+LOG_LEVEL=INFO          # DEBUG | INFO | WARNING | ERROR
+LOG_FORMAT=text         # text | json
+```
+
+---
+
+## 3. Running the Service Locally
+
+```bash
+uvicorn app.main:app --reload --port 8000
+```
+
+Verify it's running:
+
+```bash
+curl http://localhost:8000/health
+# {"status": "ok"}
+```
+
+---
+
+## 4. Exposing the Service with ngrok
+
+GitHub webhooks require a publicly accessible URL. Use ngrok to tunnel your local server:
+
+```bash
+ngrok http 8000
+```
+
+Copy the forwarding URL (e.g. `https://abc123.ngrok.io`) — you'll use it in the next step.
+
+---
+
+## 5. Configuring the GitHub Webhook
+
+1. Go to your GitHub repository → **Settings** → **Webhooks** → **Add webhook**
+2. Fill in the form:
+   - **Payload URL**: `https://abc123.ngrok.io/webhooks/github`
+   - **Content type**: `application/json`
+   - **Secret**: The same value as `GITHUB_WEBHOOK_SECRET` in your `.env`
+   - **Events**: Select **"Let me select individual events"** → check **Issues** only
+3. Click **Add webhook**
+
+---
+
+## 6. Creating a Test Issue
+
+Open a new issue in your repository. Within seconds you should see:
+
+- Labels applied automatically (e.g. `bug`, `priority-high`)
+- A triage comment posted by the bot, like:
+
+> ## 🤖 Automated Issue Triage
+>
+> | Field | Value |
+> |---|---|
+> | **Category** | 🐛 Bug |
+> | **Priority** | 🔴 High |
+> | **Suggested Labels** | `bug`, `priority-high` |
+>
+> **Reason:** The issue describes a crash on startup, indicating a high-severity bug.
+>
+> _This triage was performed automatically. A maintainer will review shortly._
+
+---
+
+## 7. Ingesting Repository Documentation (RAG)
+
+To give the LLM context from your repository docs, ingest your Markdown files:
+
+```bash
+python -m app.services.doc_ingestor ./docs
+```
+
+Or set the `DOCS_DIR` environment variable and it runs automatically on startup:
+
+```env
+DOCS_DIR=./docs
+```
+
+This embeds all `.md` files into the ChromaDB vector store, which the triage pipeline queries before each LLM call.
+
+---
+
+## 8. Viewing Metrics
+
+The service exposes a `/metrics` endpoint with triage statistics:
+
+```bash
+curl http://localhost:8000/metrics
+```
+
+Example response:
+
+```json
+{
+  "total_triaged": 42,
+  "llm_used": 38,
+  "keyword_fallback": 4,
+  "errors": 0,
+  "avg_latency_ms": 312.5,
+  "by_category": {
+    "Bug": 20,
+    "Feature Request": 12,
+    "Question": 6,
+    "Documentation": 3,
+    "Other": 1
+  },
+  "by_priority": {
+    "High": 15,
+    "Medium": 22,
+    "Low": 5
+  },
+  "feedback": {
+    "correct": 30,
+    "incorrect": 5,
+    "overridden": 7
+  }
+}
+```
+
+---
+
+## 9. Submitting Maintainer Feedback
+
+After reviewing a triage result, maintainers can submit feedback to track accuracy:
+
+```bash
+curl -X POST http://localhost:8000/feedback/myorg/myrepo/42 \
+  -H "Content-Type: application/json" \
+  -d '{"verdict": "correct", "note": "Correctly identified as a blocking bug"}'
+```
+
+Valid verdicts:
+
+| Verdict | Meaning |
+|---|---|
+| `correct` | The triage was accurate |
+| `incorrect` | The category or priority was wrong |
+| `overridden` | The maintainer changed the labels/priority |
+
+Response:
+
+```json
+{
+  "repo": "myorg/myrepo",
+  "issue_number": 42,
+  "verdict": "correct",
+  "recorded": true
+}
+```
+
+---
+
+## 10. Manual Webhook Testing (without GitHub)
+
+You can send a test webhook payload directly:
+
+```bash
+curl -X POST http://localhost:8000/webhooks/github \
+  -H "Content-Type: application/json" \
+  -H "x-github-event: issues" \
+  -d '{
+    "action": "opened",
+    "issue": {
+      "number": 1,
+      "title": "App crashes on startup",
+      "body": "Getting a traceback when I run the app. This is blocking our release."
+    },
+    "repository": {
+      "full_name": "myorg/myrepo"
+    }
+  }'
+```
+
+Expected response:
+
+```json
+{
+  "received_event": "issues",
+  "repo": "myorg/myrepo",
+  "issue_number": 1,
+  "issue_title": "App crashes on startup",
+  "triage": {
+    "repo": "myorg/myrepo",
+    "issue_number": 1,
+    "category": "Bug",
+    "priority": "High",
+    "suggested_labels": ["bug", "priority-high"],
+    "reason": "Crash on startup with a traceback; blocking keyword indicates high priority."
+  }
+}
+```
+
+---
+
+## 11. Running Tests
+
+```bash
+pytest tests/ -v
+```
+
+All 137 tests should pass.
+
+---
+
+## Environment Variable Reference
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `ANTHROPIC_API_KEY` | No | — | Enables LLM triage. Falls back to keywords if not set. |
+| `GITHUB_TOKEN` | No | — | Enables posting comments and applying labels on GitHub. |
+| `GITHUB_WEBHOOK_SECRET` | No | — | Validates HMAC-SHA256 signatures from GitHub. Recommended in production. |
+| `LOG_LEVEL` | No | `INFO` | Log verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `LOG_FORMAT` | No | `text` | `text` for human-readable, `json` for structured production logs |
+| `DOCS_DIR` | No | — | Path to Markdown docs directory to ingest into the RAG vector store |

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -4,7 +4,8 @@ import json
 import httpx
 import pytest
 
-from app.services.github_client import GitHubClient, GITHUB_API_BASE
+from app.models.triage import TriageResult
+from app.services.github_client import GitHubClient, GITHUB_API_BASE, build_triage_comment
 
 
 # ---------------------------------------------------------------------------
@@ -12,7 +13,7 @@ from app.services.github_client import GitHubClient, GITHUB_API_BASE
 # ---------------------------------------------------------------------------
 
 class _MockTransport(httpx.BaseTransport):
-    """Minimal HTTPX transport that captures requests and returns a canned response."""
+    """Single-response transport — records every request."""
 
     def __init__(self, status_code: int, body: object):
         self.status_code = status_code
@@ -25,6 +26,24 @@ class _MockTransport(httpx.BaseTransport):
             status_code=self.status_code,
             headers={"content-type": "application/json"},
             content=json.dumps(self.body).encode(),
+            request=request,
+        )
+
+
+class _MultiTransport(httpx.BaseTransport):
+    """Returns responses from a queue; last response is repeated if queue is exhausted."""
+
+    def __init__(self, responses: list[tuple[int, object]]):
+        self._queue = list(responses)
+        self.requests: list[httpx.Request] = []
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        status_code, body = self._queue[0] if len(self._queue) == 1 else self._queue.pop(0)
+        return httpx.Response(
+            status_code=status_code,
+            headers={"content-type": "application/json"},
+            content=json.dumps(body).encode(),
             request=request,
         )
 
@@ -42,6 +61,33 @@ def _make_client(status_code: int, body: object, token: str = "fake-token", base
     return GitHubClient(token=token, base_url=base_url, _client=http_client), transport
 
 
+def _make_multi_client(responses: list[tuple[int, object]], token: str = "fake-token", base_url: str = GITHUB_API_BASE):
+    """Client backed by a multi-response transport (GET labels then POST apply)."""
+    transport = _MultiTransport(responses)
+    http_client = httpx.Client(
+        transport=transport,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    return GitHubClient(token=token, base_url=base_url, _client=http_client), transport
+
+
+def _sample_result(**kwargs) -> TriageResult:
+    defaults = dict(
+        repo="owner/repo",
+        issue_number=1,
+        category="Bug",
+        priority="High",
+        suggested_labels=["bug", "priority-high"],
+        reason="Crash keyword matched",
+    )
+    defaults.update(kwargs)
+    return TriageResult(**defaults)
+
+
 # ---------------------------------------------------------------------------
 # post_comment
 # ---------------------------------------------------------------------------
@@ -50,14 +96,12 @@ class TestPostComment:
     def test_calls_correct_url(self):
         client, transport = _make_client(201, {"id": 1, "body": "Hello!"})
         client.post_comment("owner/repo", 7, "Hello!")
-        req = transport.requests[0]
-        assert req.url == f"{GITHUB_API_BASE}/repos/owner/repo/issues/7/comments"
+        assert transport.requests[0].url == f"{GITHUB_API_BASE}/repos/owner/repo/issues/7/comments"
 
     def test_sends_correct_body(self):
         client, transport = _make_client(201, {"id": 1})
         client.post_comment("owner/repo", 7, "Test comment")
-        req = transport.requests[0]
-        assert json.loads(req.content) == {"body": "Test comment"}
+        assert json.loads(transport.requests[0].content) == {"body": "Test comment"}
 
     def test_uses_post_method(self):
         client, transport = _make_client(201, {"id": 1})
@@ -67,20 +111,17 @@ class TestPostComment:
     def test_includes_auth_header(self):
         client, transport = _make_client(201, {"id": 1}, token="my-token")
         client.post_comment("owner/repo", 1, "test")
-        req = transport.requests[0]
-        assert req.headers.get("Authorization") == "Bearer my-token"
+        assert transport.requests[0].headers.get("Authorization") == "Bearer my-token"
 
     def test_includes_github_api_version_header(self):
         client, transport = _make_client(201, {"id": 1})
         client.post_comment("owner/repo", 1, "test")
-        req = transport.requests[0]
-        assert req.headers.get("X-GitHub-Api-Version") == "2022-11-28"
+        assert transport.requests[0].headers.get("X-GitHub-Api-Version") == "2022-11-28"
 
     def test_returns_response_json(self):
         expected = {"id": 99, "body": "Automated triage"}
         client, _ = _make_client(201, expected)
-        result = client.post_comment("owner/repo", 1, "Automated triage")
-        assert result == expected
+        assert client.post_comment("owner/repo", 1, "Automated triage") == expected
 
     def test_raises_on_404(self):
         client, _ = _make_client(404, {"message": "Not Found"})
@@ -94,63 +135,185 @@ class TestPostComment:
 
 
 # ---------------------------------------------------------------------------
-# apply_labels
+# apply_labels  (now calls ensure_labels_exist first → GET + POST)
 # ---------------------------------------------------------------------------
 
 class TestApplyLabels:
-    def test_calls_correct_url(self):
-        client, transport = _make_client(200, [{"name": "bug"}])
+    def test_apply_makes_get_then_post(self):
+        # GET returns existing labels, POST applies new ones
+        client, transport = _make_multi_client([
+            (200, [{"name": "bug"}]),          # GET existing labels
+            (200, [{"name": "bug"}, {"name": "priority-high"}]),  # POST apply
+        ])
+        client.apply_labels("owner/repo", 7, ["bug", "priority-high"])
+        assert transport.requests[0].method == "GET"
+        assert transport.requests[1].method == "POST"
+
+    def test_apply_posts_to_correct_url(self):
+        client, transport = _make_multi_client([
+            (200, [{"name": "bug"}]),
+            (200, [{"name": "bug"}]),
+        ])
         client.apply_labels("owner/repo", 7, ["bug"])
-        req = transport.requests[0]
-        assert req.url == f"{GITHUB_API_BASE}/repos/owner/repo/issues/7/labels"
+        post_req = transport.requests[1]
+        assert str(post_req.url) == f"{GITHUB_API_BASE}/repos/owner/repo/issues/7/labels"
 
-    def test_sends_correct_body(self):
-        client, transport = _make_client(200, [])
+    def test_apply_sends_correct_body(self):
+        # Both labels already exist → GET + POST apply (no create calls)
+        client, transport = _make_multi_client([
+            (200, [{"name": "bug"}, {"name": "priority-high"}]),  # GET — both exist
+            (200, []),                                              # POST apply
+        ])
         client.apply_labels("owner/repo", 1, ["bug", "priority-high"])
-        req = transport.requests[0]
-        assert json.loads(req.content) == {"labels": ["bug", "priority-high"]}
-
-    def test_uses_post_method(self):
-        client, transport = _make_client(200, [])
-        client.apply_labels("owner/repo", 1, ["bug"])
-        assert transport.requests[0].method == "POST"
+        assert json.loads(transport.requests[-1].content) == {"labels": ["bug", "priority-high"]}
 
     def test_returns_response_json(self):
         expected = [{"name": "bug"}, {"name": "priority-high"}]
-        client, _ = _make_client(200, expected)
+        client, _ = _make_multi_client([
+            (200, [{"name": "bug"}, {"name": "priority-high"}]),  # GET
+            (200, expected),                                        # POST
+        ])
         result = client.apply_labels("owner/repo", 1, ["bug", "priority-high"])
         assert result == expected
 
     def test_raises_on_422(self):
-        client, _ = _make_client(422, {"message": "Validation Failed"})
+        client, _ = _make_multi_client([
+            (200, []),
+            (422, {"message": "Validation Failed"}),
+        ])
         with pytest.raises(httpx.HTTPStatusError):
-            client.apply_labels("owner/repo", 1, ["nonexistent-label"])
+            client.apply_labels("owner/repo", 1, ["bad-label"])
 
     def test_accepts_empty_label_list(self):
-        client, transport = _make_client(200, [])
+        # ensure_labels_exist with empty list still does a GET, then POST
+        client, transport = _make_multi_client([
+            (200, []),  # GET
+            (200, []),  # POST
+        ])
         result = client.apply_labels("owner/repo", 1, [])
         assert result == []
-        assert json.loads(transport.requests[0].content) == {"labels": []}
 
 
 # ---------------------------------------------------------------------------
-# Client initialisation
+# ensure_labels_exist
+# ---------------------------------------------------------------------------
+
+class TestEnsureLabelsExist:
+    def test_creates_missing_label(self):
+        # GET returns no labels; POST to create; no second call expected in this path
+        client, transport = _make_multi_client([
+            (200, []),           # GET existing → empty
+            (201, {"name": "bug", "color": "d73a4a"}),  # POST create
+        ])
+        client.ensure_labels_exist("owner/repo", ["bug"])
+        assert len(transport.requests) == 2
+        assert transport.requests[1].method == "POST"
+        assert json.loads(transport.requests[1].content)["name"] == "bug"
+
+    def test_skips_existing_label(self):
+        client, transport = _make_multi_client([
+            (200, [{"name": "bug"}]),  # GET — label already exists
+        ])
+        client.ensure_labels_exist("owner/repo", ["bug"])
+        # Only the GET should have been made; no POST
+        assert len(transport.requests) == 1
+
+    def test_uses_default_color_for_known_labels(self):
+        client, transport = _make_multi_client([
+            (200, []),
+            (201, {"name": "bug"}),
+        ])
+        client.ensure_labels_exist("owner/repo", ["bug"])
+        payload = json.loads(transport.requests[1].content)
+        assert payload["color"] == "d73a4a"
+
+    def test_uses_fallback_color_for_unknown_labels(self):
+        client, transport = _make_multi_client([
+            (200, []),
+            (201, {"name": "custom-label"}),
+        ])
+        client.ensure_labels_exist("owner/repo", ["custom-label"])
+        payload = json.loads(transport.requests[1].content)
+        assert payload["color"] == "ededed"
+
+    def test_creates_multiple_missing_labels(self):
+        client, transport = _make_multi_client([
+            (200, [{"name": "bug"}]),   # GET — bug exists
+            (201, {"name": "priority-high"}),  # POST create priority-high
+        ])
+        client.ensure_labels_exist("owner/repo", ["bug", "priority-high"])
+        assert len(transport.requests) == 2  # 1 GET + 1 POST
+
+
+# ---------------------------------------------------------------------------
+# build_triage_comment
+# ---------------------------------------------------------------------------
+
+class TestBuildTriageComment:
+    def test_contains_category(self):
+        result = _sample_result(category="Bug")
+        comment = build_triage_comment(result)
+        assert "Bug" in comment
+
+    def test_contains_priority(self):
+        result = _sample_result(priority="High")
+        comment = build_triage_comment(result)
+        assert "High" in comment
+
+    def test_contains_labels(self):
+        result = _sample_result(suggested_labels=["bug", "priority-high"])
+        comment = build_triage_comment(result)
+        assert "`bug`" in comment
+        assert "`priority-high`" in comment
+
+    def test_contains_reason(self):
+        result = _sample_result(reason="Crash keyword matched")
+        comment = build_triage_comment(result)
+        assert "Crash keyword matched" in comment
+
+    def test_bug_emoji(self):
+        result = _sample_result(category="Bug")
+        assert "🐛" in build_triage_comment(result)
+
+    def test_feature_request_emoji(self):
+        result = _sample_result(category="Feature Request", priority="Low", suggested_labels=["feature-request"])
+        assert "✨" in build_triage_comment(result)
+
+    def test_high_priority_emoji(self):
+        result = _sample_result(priority="High")
+        assert "🔴" in build_triage_comment(result)
+
+    def test_low_priority_emoji(self):
+        result = _sample_result(priority="Low")
+        assert "🟢" in build_triage_comment(result)
+
+    def test_is_markdown_table(self):
+        result = _sample_result()
+        comment = build_triage_comment(result)
+        assert "|" in comment
+
+    def test_contains_automated_footer(self):
+        result = _sample_result()
+        comment = build_triage_comment(result)
+        assert "automatically" in comment.lower()
+
+
+# ---------------------------------------------------------------------------
+# Client init
 # ---------------------------------------------------------------------------
 
 class TestClientInit:
     def test_custom_base_url(self):
         custom_base = "https://github.example.com/api/v3"
-        client, transport = _make_client(201, {"id": 1}, base_url=custom_base)
-        # Re-create with the custom base_url passed to GitHubClient
-        transport2 = _MockTransport(201, {"id": 1})
-        http_client = httpx.Client(transport=transport2, headers={
+        transport = _MockTransport(201, {"id": 1})
+        http_client = httpx.Client(transport=transport, headers={
             "Authorization": "Bearer tok",
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
         })
         gc = GitHubClient(token="tok", base_url=custom_base, _client=http_client)
         gc.post_comment("owner/repo", 1, "test")
-        assert str(transport2.requests[0].url).startswith(custom_base)
+        assert str(transport.requests[0].url).startswith(custom_base)
 
     def test_trailing_slash_stripped_from_base_url(self):
         transport = _MockTransport(201, {"id": 1})
@@ -161,6 +324,4 @@ class TestClientInit:
         })
         gc = GitHubClient(token="tok", base_url="https://api.github.com/", _client=http_client)
         gc.post_comment("owner/repo", 1, "test")
-        url_str = str(transport.requests[0].url)
-        # Should not have double slashes after scheme
-        assert "//repos" not in url_str
+        assert "//repos" not in str(transport.requests[0].url)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,202 @@
+"""Tests for Phase 4: metrics, feedback endpoint, and logging config."""
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.triage import TriageResult
+from app.services.metrics import TriageMetrics, track_triage_duration
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _result(**kwargs) -> TriageResult:
+    defaults = dict(
+        repo="owner/repo",
+        issue_number=1,
+        category="Bug",
+        priority="High",
+        suggested_labels=["bug", "priority-high"],
+        reason="crash matched",
+    )
+    defaults.update(kwargs)
+    return TriageResult(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# TriageMetrics unit tests
+# ---------------------------------------------------------------------------
+
+class TestTriageMetrics:
+    def setup_method(self):
+        self.m = TriageMetrics()
+
+    def test_initial_state_is_zero(self):
+        d = self.m.to_dict()
+        assert d["total_triaged"] == 0
+        assert d["errors"] == 0
+        assert d["avg_latency_ms"] == 0.0
+
+    def test_record_triage_increments_total(self):
+        self.m.record_triage(_result(), used_llm=False, latency_ms=10.0)
+        assert self.m.to_dict()["total_triaged"] == 1
+
+    def test_record_triage_tracks_llm_vs_keyword(self):
+        self.m.record_triage(_result(), used_llm=True, latency_ms=100.0)
+        self.m.record_triage(_result(), used_llm=False, latency_ms=5.0)
+        d = self.m.to_dict()
+        assert d["llm_used"] == 1
+        assert d["keyword_fallback"] == 1
+
+    def test_record_triage_tracks_category(self):
+        self.m.record_triage(_result(category="Bug"), used_llm=False, latency_ms=1.0)
+        self.m.record_triage(_result(category="Question"), used_llm=False, latency_ms=1.0)
+        d = self.m.to_dict()
+        assert d["by_category"]["Bug"] == 1
+        assert d["by_category"]["Question"] == 1
+
+    def test_record_triage_tracks_priority(self):
+        self.m.record_triage(_result(priority="High"), used_llm=False, latency_ms=1.0)
+        self.m.record_triage(_result(priority="Low"), used_llm=False, latency_ms=1.0)
+        d = self.m.to_dict()
+        assert d["by_priority"]["High"] == 1
+        assert d["by_priority"]["Low"] == 1
+
+    def test_avg_latency_calculated_correctly(self):
+        self.m.record_triage(_result(), used_llm=False, latency_ms=100.0)
+        self.m.record_triage(_result(), used_llm=False, latency_ms=200.0)
+        assert self.m.avg_latency_ms == 150.0
+
+    def test_record_error_increments_errors(self):
+        self.m.record_error()
+        self.m.record_error()
+        assert self.m.to_dict()["errors"] == 2
+
+    def test_record_feedback(self):
+        self.m.record_feedback("correct")
+        self.m.record_feedback("correct")
+        self.m.record_feedback("incorrect")
+        d = self.m.to_dict()
+        assert d["feedback"]["correct"] == 2
+        assert d["feedback"]["incorrect"] == 1
+
+    def test_reset_clears_all(self):
+        self.m.record_triage(_result(), used_llm=True, latency_ms=50.0)
+        self.m.record_error()
+        self.m.record_feedback("correct")
+        self.m.reset()
+        d = self.m.to_dict()
+        assert d["total_triaged"] == 0
+        assert d["errors"] == 0
+        assert d["feedback"] == {}
+
+
+# ---------------------------------------------------------------------------
+# track_triage_duration context manager
+# ---------------------------------------------------------------------------
+
+class TestTrackTriageDuration:
+    def test_records_elapsed_time(self):
+        with track_triage_duration() as info:
+            pass
+        assert "latency_ms" in info
+        assert info["latency_ms"] >= 0
+
+    def test_latency_is_non_negative_float(self):
+        with track_triage_duration() as info:
+            pass
+        assert isinstance(info["latency_ms"], float)
+        assert info["latency_ms"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# /metrics endpoint
+# ---------------------------------------------------------------------------
+
+class TestMetricsEndpoint:
+    def setup_method(self):
+        from app.services.metrics import metrics
+        metrics.reset()
+
+    def test_metrics_endpoint_returns_200(self):
+        from app.main import app
+        client = TestClient(app)
+        response = client.get("/metrics")
+        assert response.status_code == 200
+
+    def test_metrics_endpoint_returns_expected_keys(self):
+        from app.main import app
+        client = TestClient(app)
+        data = client.get("/metrics").json()
+        for key in ("total_triaged", "llm_used", "keyword_fallback", "errors",
+                    "avg_latency_ms", "by_category", "by_priority", "feedback"):
+            assert key in data
+
+    def test_metrics_reflects_triage_call(self):
+        from app.main import app
+        from app.services.metrics import metrics
+        client = TestClient(app)
+
+        # Trigger a real triage via webhook
+        payload = json.dumps({
+            "action": "opened",
+            "issue": {"number": 1, "title": "App crashes", "body": ""},
+            "repository": {"full_name": "owner/repo"},
+        }).encode()
+        client.post("/webhooks/github", content=payload,
+                    headers={"x-github-event": "issues", "content-type": "application/json"})
+
+        data = client.get("/metrics").json()
+        assert data["total_triaged"] == 1
+
+
+# ---------------------------------------------------------------------------
+# /feedback endpoint
+# ---------------------------------------------------------------------------
+
+class TestFeedbackEndpoint:
+    def setup_method(self):
+        from app.services.metrics import metrics
+        metrics.reset()
+
+    @pytest.fixture
+    def client(self):
+        from app.main import app
+        return TestClient(app)
+
+    def test_valid_feedback_correct(self, client):
+        resp = client.post("/feedback/owner/repo/42", json={"verdict": "correct"})
+        assert resp.status_code == 200
+        assert resp.json()["verdict"] == "correct"
+        assert resp.json()["recorded"] is True
+
+    def test_valid_feedback_incorrect(self, client):
+        resp = client.post("/feedback/owner/repo/42", json={"verdict": "incorrect"})
+        assert resp.status_code == 200
+
+    def test_valid_feedback_overridden(self, client):
+        resp = client.post("/feedback/owner/repo/42", json={"verdict": "overridden"})
+        assert resp.status_code == 200
+
+    def test_invalid_verdict_returns_400(self, client):
+        resp = client.post("/feedback/owner/repo/42", json={"verdict": "bad-verdict"})
+        assert resp.status_code == 400
+
+    def test_feedback_recorded_in_metrics(self, client):
+        from app.services.metrics import metrics
+        client.post("/feedback/owner/repo/1", json={"verdict": "correct"})
+        client.post("/feedback/owner/repo/2", json={"verdict": "incorrect"})
+        assert metrics.feedback_counts["correct"] == 1
+        assert metrics.feedback_counts["incorrect"] == 1
+
+    def test_feedback_response_contains_repo_and_issue(self, client):
+        resp = client.post("/feedback/myorg/myrepo/99", json={"verdict": "correct"})
+        data = resp.json()
+        assert data["repo"] == "myorg/myrepo"
+        assert data["issue_number"] == 99
+
+    def test_feedback_with_note(self, client):
+        resp = client.post("/feedback/owner/repo/1",
+                           json={"verdict": "overridden", "note": "Changed to documentation"})
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- Add \`logging_config.py\` — configures log level and format (\`text\`/\`json\`) from env vars
- Add \`metrics.py\` — in-process triage metrics: counts, latency, category/priority breakdown, errors, and feedback verdicts; exposed via \`GET /metrics\`
- Add \`POST /feedback/{owner}/{repo}/{issue}\` endpoint for maintainer verdicts (\`correct\`, \`incorrect\`, \`overridden\`)
- Update \`issue_processor.py\` — records latency and LLM-vs-keyword metrics on every triage
- Add \`docs/how-to.md\` — end-to-end setup guide with curl examples, ngrok/webhook config, RAG ingestion, metrics, and feedback usage
- Update \`README.md\` — quick start, feature list, architecture diagram, API table, env reference

## Test plan
- [x] 137 tests passing across 7 test files
- [x] 21 new tests in \`test_metrics.py\` covering TriageMetrics unit tests, \`/metrics\` endpoint, and \`/feedback\` endpoint
- [x] All Phase 1–3 tests continue to pass