### PR TITLE
Refactor LLM triage to LangChain with LangSmith tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ When an issue is created, the bot posts:
 | `LOG_LEVEL` | No | `DEBUG` / `INFO` / `WARNING` / `ERROR` (default: `INFO`) |
 | `LOG_FORMAT` | No | `text` or `json` (default: `text`) |
 | `DOCS_DIR` | No | Path to Markdown docs to ingest into the RAG vector store. |
+| `LANGCHAIN_TRACING_V2` | No | Set to `true` to enable LangSmith tracing of every LLM chain invocation. |
+| `LANGCHAIN_API_KEY` | No | Your LangSmith API key (required when tracing is enabled). |
+| `LANGCHAIN_PROJECT` | No | LangSmith project name to send traces to (default: `default`). |
 
 ---
 
@@ -116,7 +119,8 @@ FastAPI Backend  ──► Issue Processor
 ## Tech Stack
 
 - **Backend**: Python, FastAPI
-- **LLM**: Anthropic Claude (`claude-haiku-4-5`)
+- **LLM**: Anthropic Claude (`claude-haiku-4-5`) via LangChain
+- **Tracing**: LangSmith (auto-enabled via `LANGCHAIN_TRACING_V2`)
 - **RAG**: ChromaDB vector store
 - **GitHub Integration**: Webhooks + REST API via httpx
 - **Testing**: pytest (137 tests)

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -1,44 +1,51 @@
+"""LangChain-based LLM triage pipeline.
+
+Chain structure:
+  ChatPromptTemplate (system + human) → ChatAnthropic.with_structured_output(TriageOutput)
+
+The prompt is rendered with {repo}, {title}, {body}, {context} and piped into
+ChatAnthropic, which calls a structured-output tool and returns a TriageOutput
+Pydantic object directly. That is then mapped to the TriageResult domain model.
+
+LangSmith tracing is automatic when LANGCHAIN_TRACING_V2=true and
+LANGCHAIN_API_KEY are set — no extra code required.
+"""
 import logging
 import os
+from typing import Literal
 
-import anthropic
+from langchain_anthropic import ChatAnthropic
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel, Field
 
 from app.models.triage import TriageResult
 
 logger = logging.getLogger(__name__)
 
-_TRIAGE_TOOL = {
-    "name": "triage_issue",
-    "description": (
-        "Classify and prioritize a GitHub issue. "
-        "Return the category, priority, suggested labels, and a brief reason."
-    ),
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "category": {
-                "type": "string",
-                "enum": ["Bug", "Feature Request", "Documentation", "Question", "Other"],
-                "description": "The nature of the issue.",
-            },
-            "priority": {
-                "type": "string",
-                "enum": ["High", "Medium", "Low"],
-                "description": "Urgency level based on impact and severity.",
-            },
-            "suggested_labels": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "GitHub labels to apply (e.g. 'bug', 'priority-high').",
-            },
-            "reason": {
-                "type": "string",
-                "description": "One or two sentences explaining the triage decision.",
-            },
-        },
-        "required": ["category", "priority", "suggested_labels", "reason"],
-    },
-}
+# ---------------------------------------------------------------------------
+# Structured output schema
+# ---------------------------------------------------------------------------
+
+class TriageOutput(BaseModel):
+    """Pydantic schema that the LLM must populate via structured output / tool call."""
+
+    category: Literal["Bug", "Feature Request", "Documentation", "Question", "Other"] = Field(
+        description="The nature of the issue."
+    )
+    priority: Literal["High", "Medium", "Low"] = Field(
+        description="Urgency level based on impact and severity."
+    )
+    suggested_labels: list[str] = Field(
+        description="GitHub labels to apply (e.g. 'bug', 'priority-high')."
+    )
+    reason: str = Field(
+        description="One or two sentences explaining the triage decision."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt template
+# ---------------------------------------------------------------------------
 
 _SYSTEM_PROMPT = (
     "You are a senior open-source maintainer performing issue triage. "
@@ -47,6 +54,19 @@ _SYSTEM_PROMPT = (
     "Be concise and consistent."
 )
 
+_PROMPT = ChatPromptTemplate.from_messages([
+    ("system", _SYSTEM_PROMPT),
+    (
+        "human",
+        "Repository: {repo}\n\nTitle: {title}\n\nBody:\n{body}"
+        "{context_section}",
+    ),
+])
+
+
+# ---------------------------------------------------------------------------
+# Public function
+# ---------------------------------------------------------------------------
 
 def classify_with_llm(
     repo: str,
@@ -58,38 +78,46 @@ def classify_with_llm(
     api_key: str | None = None,
     model: str = "claude-haiku-4-5-20251001",
 ) -> TriageResult:
-    """Classify a GitHub issue using Claude. Raises on any API error."""
-    client = anthropic.Anthropic(api_key=api_key or os.getenv("ANTHROPIC_API_KEY"))
+    """Classify a GitHub issue using a LangChain → Claude pipeline.
 
-    user_content = f"Repository: {repo}\n\nTitle: {title}\n\nBody:\n{body or '(no body)'}"
-    if context:
-        user_content += f"\n\n--- Relevant context from repository ---\n{context}"
-
-    logger.debug("Sending issue %s#%d to LLM for triage", repo, issue_number)
-    response = client.messages.create(
+    Raises on any API or validation error (caller handles fallback).
+    LangSmith tracing is automatic when LANGCHAIN_TRACING_V2=true.
+    """
+    llm = ChatAnthropic(
         model=model,
+        api_key=api_key or os.getenv("ANTHROPIC_API_KEY"),
         max_tokens=512,
-        system=_SYSTEM_PROMPT,
-        tools=[_TRIAGE_TOOL],
-        tool_choice={"type": "tool", "name": "triage_issue"},
-        messages=[{"role": "user", "content": user_content}],
     )
 
-    tool_use = next(b for b in response.content if b.type == "tool_use")
-    data = tool_use.input
+    # Build the chain: prompt | model with structured output
+    chain = _PROMPT | llm.with_structured_output(TriageOutput)
+
+    context_section = (
+        f"\n\n--- Relevant context from repository ---\n{context}" if context else ""
+    )
+
+    logger.debug("Sending issue %s#%d to LLM chain for triage", repo, issue_number)
+
+    output: TriageOutput = chain.invoke({
+        "repo": repo,
+        "title": title,
+        "body": body or "(no body)",
+        "context_section": context_section,
+    })
 
     logger.info(
         "LLM triage for %s#%d — category=%s priority=%s",
         repo,
         issue_number,
-        data["category"],
-        data["priority"],
+        output.category,
+        output.priority,
     )
+
     return TriageResult(
         repo=repo,
         issue_number=issue_number,
-        category=data["category"],
-        priority=data["priority"],
-        suggested_labels=data["suggested_labels"],
-        reason=data["reason"],
+        category=output.category,
+        priority=output.priority,
+        suggested_labels=output.suggested_labels,
+        reason=output.reason,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "anthropic>=0.49.0",
+    "langchain-anthropic>=0.3.0",
+    "langchain-core>=0.3.0",
     "chromadb>=0.6.0",
     "fastapi>=0.129.0",
     "httpx>=0.28.1",

--- a/tests/test_issue_processor.py
+++ b/tests/test_issue_processor.py
@@ -4,10 +4,6 @@ import pytest
 
 from app.models.triage import TriageResult
 from app.services.issue_processor import _keyword_triage, triage_issue
-import pytest
-
-from app.models.triage import TriageResult
-from app.services.issue_processor import triage_issue
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -1,39 +1,58 @@
-"""Tests for the LLM triage service.
+"""Tests for the LangChain-based LLM triage service.
 
-All tests mock the Anthropic client so no real API calls are made.
+We mock the ChatAnthropic model so no real API calls are made.
+
+The chain is:  ChatPromptTemplate | ChatAnthropic.with_structured_output(TriageOutput)
+
+Strategy: patch `langchain_anthropic.ChatAnthropic` so that
+`llm.with_structured_output(TriageOutput)` returns a real `RunnableLambda`
+that emits a fake TriageOutput. The lambda receives the rendered prompt as
+input, so we can also assert what variables were passed in.
 """
-
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from langchain_core.runnables import RunnableLambda
 
-from app.services.llm_service import classify_with_llm
+from app.services.llm_service import TriageOutput, classify_with_llm
 
 
-def _make_llm_response(category="Bug", priority="High", labels=None, reason="test reason"):
-    """Build a fake Anthropic messages.create() response."""
-    if labels is None:
-        labels = ["bug", "priority-high"]
-    tool_use_block = SimpleNamespace(
-        type="tool_use",
-        input={
-            "category": category,
-            "priority": priority,
-            "suggested_labels": labels,
-            "reason": reason,
-        },
+def _fake_output(
+    category="Bug",
+    priority="High",
+    labels=None,
+    reason="test reason",
+) -> TriageOutput:
+    return TriageOutput(
+        category=category,
+        priority=priority,
+        suggested_labels=labels or ["bug", "priority-high"],
+        reason=reason,
     )
-    return SimpleNamespace(content=[tool_use_block])
 
 
-@patch("app.services.llm_service.anthropic.Anthropic")
-def test_classify_returns_triage_result(mock_anthropic_cls):
-    mock_client = MagicMock()
-    mock_anthropic_cls.return_value = mock_client
-    mock_client.messages.create.return_value = _make_llm_response(
-        category="Bug", priority="High", labels=["bug", "priority-high"], reason="Crash in prod"
-    )
+def _patch_chat_anthropic(mock_cls, output: TriageOutput, capture: list | None = None):
+    """Wire up mock_cls so chain `_PROMPT | llm.with_structured_output(...)` returns `output`.
+
+    If `capture` is provided, each invocation of the lambda appends the rendered
+    prompt to it so tests can inspect what reached the LLM stage.
+    """
+    def _lambda(prompt_value):
+        if capture is not None:
+            capture.append(prompt_value)
+        return output
+
+    mock_llm = MagicMock()
+    mock_llm.with_structured_output.return_value = RunnableLambda(_lambda)
+    mock_cls.return_value = mock_llm
+    return mock_llm
+
+
+@patch("app.services.llm_service.ChatAnthropic")
+def test_classify_returns_triage_result(mock_cls):
+    _patch_chat_anthropic(mock_cls, _fake_output(
+        category="Bug", priority="High", labels=["bug", "priority-high"], reason="Crash in prod",
+    ))
 
     result = classify_with_llm("owner/repo", 42, "App crashes on startup", "", api_key="fake")
 
@@ -45,27 +64,38 @@ def test_classify_returns_triage_result(mock_anthropic_cls):
     assert result.issue_number == 42
 
 
-@patch("app.services.llm_service.anthropic.Anthropic")
-def test_classify_passes_correct_args_to_api(mock_anthropic_cls):
-    mock_client = MagicMock()
-    mock_anthropic_cls.return_value = mock_client
-    mock_client.messages.create.return_value = _make_llm_response()
+@patch("app.services.llm_service.ChatAnthropic")
+def test_classify_renders_title_and_body_into_prompt(mock_cls):
+    captured: list = []
+    _patch_chat_anthropic(mock_cls, _fake_output(), capture=captured)
 
     classify_with_llm("owner/repo", 1, "My title", "My body", api_key="fake")
 
-    call_kwargs = mock_client.messages.create.call_args.kwargs
-    assert call_kwargs["tool_choice"] == {"type": "tool", "name": "triage_issue"}
-    assert "My title" in call_kwargs["messages"][0]["content"]
-    assert "My body" in call_kwargs["messages"][0]["content"]
+    # captured[0] is the rendered ChatPromptValue. Stringifying gives the messages.
+    rendered = str(captured[0])
+    assert "My title" in rendered
+    assert "My body" in rendered
+    assert "owner/repo" in rendered
 
 
-@patch("app.services.llm_service.anthropic.Anthropic")
-def test_classify_feature_request(mock_anthropic_cls):
-    mock_client = MagicMock()
-    mock_anthropic_cls.return_value = mock_client
-    mock_client.messages.create.return_value = _make_llm_response(
-        category="Feature Request", priority="Low", labels=["feature-request", "priority-low"]
-    )
+@patch("app.services.llm_service.ChatAnthropic")
+def test_classify_includes_context_section(mock_cls):
+    captured: list = []
+    _patch_chat_anthropic(mock_cls, _fake_output(), capture=captured)
+
+    classify_with_llm("owner/repo", 1, "title", "body",
+                     context="some retrieved doc", api_key="fake")
+
+    rendered = str(captured[0])
+    assert "some retrieved doc" in rendered
+
+
+@patch("app.services.llm_service.ChatAnthropic")
+def test_classify_feature_request(mock_cls):
+    _patch_chat_anthropic(mock_cls, _fake_output(
+        category="Feature Request", priority="Low",
+        labels=["feature-request", "priority-low"],
+    ))
 
     result = classify_with_llm("owner/repo", 7, "Add dark mode", "", api_key="fake")
 
@@ -73,11 +103,14 @@ def test_classify_feature_request(mock_anthropic_cls):
     assert result.priority == "Low"
 
 
-@patch("app.services.llm_service.anthropic.Anthropic")
-def test_classify_propagates_api_error(mock_anthropic_cls):
-    mock_client = MagicMock()
-    mock_anthropic_cls.return_value = mock_client
-    mock_client.messages.create.side_effect = Exception("API unavailable")
+@patch("app.services.llm_service.ChatAnthropic")
+def test_classify_propagates_api_error(mock_cls):
+    def _raise(_):
+        raise Exception("API unavailable")
+
+    mock_llm = MagicMock()
+    mock_llm.with_structured_output.return_value = RunnableLambda(_raise)
+    mock_cls.return_value = mock_llm
 
     with pytest.raises(Exception, match="API unavailable"):
         classify_with_llm("owner/repo", 1, "title", "body", api_key="fake")


### PR DESCRIPTION
- Rewrite llm_service.py as a LangChain chain: ChatPromptTemplate | ChatAnthropic.with_structured_output(TriageOutput). TriageOutput is a Pydantic schema mirroring TriageResult fields.
- LangSmith tracing is automatic when LANGCHAIN_TRACING_V2 / LANGCHAIN_API_KEY / LANGCHAIN_PROJECT env vars are set.
- Add langchain-anthropic and langchain-core to pyproject.toml.
- Update tests/test_llm_service.py: mock ChatAnthropic and inject a RunnableLambda so the prompt composes naturally and we can assert what variables reach the LLM stage.
- Document LangSmith env vars in README.md.
- Remove stray duplicate imports in tests/test_issue_processor.py.

138/138 tests passing.