### PR TITLE
Structure-aware chunking + Gemini provider + eval suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ wheels/
 .pytest_cache/
 .coverage
 htmlcov/
+
+
+# Eval suite local results
+tests/eval/results/

--- a/README.md
+++ b/README.md
@@ -1,148 +1,177 @@
 # GitHub Issue Triage
 
-An AI-powered service that automatically classifies, prioritizes, and labels GitHub issues using large language models and retrieval-augmented generation (RAG).
+A production-style service that classifies, prioritizes, and labels new GitHub issues using an LLM with retrieval-augmented context from the repository's own documentation.
+
+[![tests](https://img.shields.io/badge/tests-147%20passing-success)](#testing)
+[![providers](https://img.shields.io/badge/LLM-Anthropic_%7C_Gemini-blue)](#configuration)
+[![python](https://img.shields.io/badge/python-3.10%2B-blue)](pyproject.toml)
 
 ---
 
-## Overview
+## What it does
 
-Managing GitHub issues at scale is time-consuming and inconsistent. This service hooks into GitHub webhooks to triage new issues in real time — no manual review needed for the initial pass.
+When a new issue is opened on a configured GitHub repository:
 
-When a new issue is opened, the service:
+1. The webhook hits a FastAPI endpoint with HMAC-SHA256 signature verification.
+2. The triage service retrieves the most semantically similar chunks of the repo's documentation from a ChromaDB vector store.
+3. An LLM (Anthropic Claude or Google Gemini, swappable via env var) returns a structured `TriageOutput` with category, priority, suggested labels, and a reasoning string.
+4. The service auto-creates any missing labels in the repository, applies them to the issue, and posts a formatted triage comment.
+5. Metrics (counts, latency, category/priority breakdown, maintainer feedback) are tracked in-process and exposed at `/metrics`.
 
-1. Retrieves relevant context from your repository docs and past issues (RAG)
-2. Sends the issue to Claude for classification (falls back to keyword matching if no API key)
-3. Applies labels automatically via the GitHub API
-4. Posts a structured triage summary as a comment
-
----
-
-## Features
-
-- **Automated classification** — Bug, Feature Request, Documentation, Question, Other
-- **Priority inference** — High, Medium, Low based on content signals
-- **Label management** — Suggests and auto-creates labels, applies them to the issue
-- **RAG context** — Embeds your repository docs and past issues into ChromaDB for richer LLM context
-- **Webhook signature verification** — HMAC-SHA256 validation of all incoming GitHub events
-- **Observability** — Structured logging, in-process metrics endpoint (`GET /metrics`)
-- **Feedback loop** — Maintainers can rate triage accuracy via `POST /feedback`
-- **Graceful degradation** — Every external dependency (LLM, RAG, GitHub API) degrades silently so triage always completes
-
----
-
-## Quick Start
-
-```bash
-# 1. Clone and install
-git clone https://github.com/hundehanna/Github-Issue-Triage.git
-cd Github-Issue-Triage
-pip install .
-
-# 2. Configure environment
-cp .env.example .env   # edit with your keys
-
-# 3. Run
-uvicorn app.main:app --reload --port 8000
-
-# 4. Expose via ngrok (for local webhook testing)
-ngrok http 8000
-```
-
-Then configure a GitHub webhook pointing to `https://<your-ngrok-url>/webhooks/github` with event type **Issues**.
-
-See [docs/how-to.md](docs/how-to.md) for the full setup guide with examples.
-
----
-
-## Example Triage Comment
-
-When an issue is created, the bot posts:
-
-> ## 🤖 Automated Issue Triage
->
-> | Field | Value |
-> |---|---|
-> | **Category** | 🐛 Bug |
-> | **Priority** | 🔴 High |
-> | **Suggested Labels** | `bug`, `priority-high` |
->
-> **Reason:** The issue describes a crash on startup with a traceback; blocking keyword indicates high priority.
->
-> _This triage was performed automatically. A maintainer will review shortly._
-
----
-
-## API Endpoints
-
-| Method | Path | Description |
-|---|---|---|
-| `GET` | `/health` | Health check |
-| `POST` | `/webhooks/github` | GitHub webhook receiver |
-| `GET` | `/metrics` | Triage metrics (counts, latency, breakdown) |
-| `POST` | `/feedback/{owner}/{repo}/{issue}` | Submit maintainer feedback on triage accuracy |
-
----
-
-## Environment Variables
-
-| Variable | Required | Description |
-|---|---|---|
-| `ANTHROPIC_API_KEY` | No | Enables LLM triage via Claude. Falls back to keyword matching if unset. |
-| `GITHUB_TOKEN` | No | Enables posting comments and applying labels on GitHub. |
-| `GITHUB_WEBHOOK_SECRET` | No | Validates HMAC-SHA256 signatures. Recommended in production. |
-| `LOG_LEVEL` | No | `DEBUG` / `INFO` / `WARNING` / `ERROR` (default: `INFO`) |
-| `LOG_FORMAT` | No | `text` or `json` (default: `text`) |
-| `DOCS_DIR` | No | Path to Markdown docs to ingest into the RAG vector store. |
-| `LANGCHAIN_TRACING_V2` | No | Set to `true` to enable LangSmith tracing of every LLM chain invocation. |
-| `LANGCHAIN_API_KEY` | No | Your LangSmith API key (required when tracing is enabled). |
-| `LANGCHAIN_PROJECT` | No | LangSmith project name to send traces to (default: `default`). |
+The pipeline degrades gracefully — if the LLM, RAG, or GitHub API is unavailable, the service falls back to keyword-based triage and continues to respond.
 
 ---
 
 ## Architecture
 
 ```
-GitHub Repository
-      │
-      ▼ (webhook on issue opened)
-FastAPI Backend  ──► Issue Processor
-                         │
-                         ├── RAG Retrieval (ChromaDB)
-                         ├── LLM Service (Anthropic Claude)
-                         │     └── keyword fallback
-                         ├── GitHub Client (labels + comment)
-                         └── Metrics
+                          ┌──────────────────────────────┐
+GitHub Webhook ──────────▶│  FastAPI                     │
+(X-Hub-Signature-256)     │  • HMAC verification         │
+                          │  • Payload parsing            │
+                          └─────────────┬────────────────┘
+                                        │
+                          ┌─────────────▼────────────────┐
+                          │  Issue Processor              │
+                          │  • Latency timer              │
+                          │  • Metrics + error tracking   │
+                          └─────────────┬────────────────┘
+                                        │
+                  ┌─────────────────────┼──────────────────────┐
+                  ▼                     ▼                      ▼
+        ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐
+        │ RAG Retrieval    │  │ LLM Chain        │  │ Keyword Fallback │
+        │ (ChromaDB)       │  │ (LangChain)      │  │                  │
+        │ • docs + issues  │  │ • Claude/Gemini  │  │ Always available │
+        │ • cosine search  │  │ • structured     │  │ Activates on     │
+        │ • heading-aware  │  │   output schema  │  │ LLM/API failure  │
+        └──────────────────┘  └────────┬─────────┘  └──────────────────┘
+                                       │
+                          ┌────────────▼─────────────┐
+                          │  GitHub Client            │
+                          │  • Auto-create labels     │
+                          │  • Apply labels           │
+                          │  • Post triage comment    │
+                          └───────────────────────────┘
 ```
 
 ---
 
-## Tech Stack
+## Highlights
 
-- **Backend**: Python, FastAPI
-- **LLM**: Anthropic Claude (`claude-haiku-4-5`) via LangChain
-- **Tracing**: LangSmith (auto-enabled via `LANGCHAIN_TRACING_V2`)
-- **RAG**: ChromaDB vector store
-- **GitHub Integration**: Webhooks + REST API via httpx
-- **Testing**: pytest (137 tests)
+- **Provider-agnostic LLM layer.** `LLM_PROVIDER=anthropic|gemini` swaps the underlying model with no code changes. Composed as a LangChain pipeline (`prompt | model | structured_output`).
+- **LangSmith tracing.** Zero-code observability — set `LANGCHAIN_TRACING_V2=true` and every LLM call appears in the LangSmith dashboard with inputs, outputs, latency, and token counts.
+- **Structure-aware document chunking.** Two-stage strategy: `MarkdownHeaderTextSplitter` preserves author-intended section boundaries; `RecursiveCharacterTextSplitter` splits oversized sections at paragraph/sentence boundaries. Heading hierarchy is preserved as chunk metadata.
+- **Eval suite.** 10 labeled scenarios with expected triage decisions and retrieval keywords; standalone runner produces a scorecard and timestamped JSON for A/B comparisons.
+- **Graceful degradation.** Every external dependency (LLM, vector store, GitHub API) has a failure path. The service never returns 5xx for a triage failure.
+- **Webhook signature verification.** HMAC-SHA256 validation gated on `GITHUB_WEBHOOK_SECRET`.
+- **Maintainer feedback loop.** `POST /feedback/{owner}/{repo}/{issue}` records correct / incorrect / overridden verdicts in the metrics surface.
 
 ---
 
-## Running Tests
+## Eval results
+
+The chunking strategy was refactored from fixed 512-character chunks to a structure-aware splitter. The eval suite measured the impact:
+
+| Case | Fixed chunking | Heading-aware | Notes |
+|---|---|---|---|
+| `q_webhook_signature_verification` | 1.00 | 1.00 | — |
+| `q_json_logging_env_var` | **0.00** | **1.00** | ★ env-var table now stays in one chunk |
+| `q_docs_ingestion_command` | 1.00 | 1.00 | — |
+| `q_feedback_verdicts_meaning` | 1.00 | 0.50 | regression: different chunk retrieved |
+| `q_categories_supported` | 0.25 | 0.25 | — bulleted list still gets split |
+| `bug_metrics_endpoint_404` | 1.00 | 1.00 | — |
+
+Triage-quality scores (category accuracy, priority accuracy, label F1) remained essentially unchanged — the LLM was already strong at those. The retrieval column was the discriminating signal.
+
+**Headline:** one deterministic fix on the predicted failure case, one regression discovered through measurement, and rich heading-path metadata now attached to every chunk. The eval methodology itself — reproducible, case-grained, scored — is the bigger contribution than any specific delta.
+
+Reproduce locally:
 
 ```bash
-pytest tests/ -v
+python -m tests.eval.run_eval --label heading-aware-chunking
 ```
+
+See [`tests/eval/README.md`](tests/eval/README.md) for the scoring rubric and case schema.
 
 ---
 
-## Documentation
+## API
 
-- [How-To Guide](docs/how-to.md) — full setup, examples, and API reference
-- [Project Spec](docs/project_spec.md) — original specification and phase breakdown
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/health` | Liveness probe |
+| `POST` | `/webhooks/github` | GitHub webhook receiver (event: `issues`, action: `opened`) |
+| `GET` | `/metrics` | Aggregate triage metrics |
+| `POST` | `/feedback/{owner}/{repo}/{issue}` | Submit maintainer verdict (`correct`, `incorrect`, `overridden`) |
+
+---
+
+## Configuration
+
+| Variable | Description |
+|---|---|
+| `LLM_PROVIDER` | `anthropic` (default) or `gemini` |
+| `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY` | API key for the active provider |
+| `ANTHROPIC_MODEL` / `GEMINI_MODEL` | Optional model override (defaults: `claude-haiku-4-5-20251001`, `gemini-2.5-flash`) |
+| `GITHUB_TOKEN` | Personal access token; required to post comments and apply labels |
+| `GITHUB_WEBHOOK_SECRET` | Enables HMAC-SHA256 signature verification |
+| `CHROMA_DB_PATH` | Path for persistent vector store (default: ephemeral in-memory) |
+| `LOG_LEVEL`, `LOG_FORMAT` | Standard `INFO`/`DEBUG`/etc., and `text`/`json` |
+| `LANGCHAIN_TRACING_V2`, `LANGCHAIN_API_KEY`, `LANGCHAIN_PROJECT` | Optional LangSmith tracing |
+
+---
+
+## Quick start
+
+```bash
+# 1. Install
+pip install .
+
+# 2. Configure (see Configuration above)
+cp .env.example .env
+
+# 3. Ingest your repo's docs into the vector store
+python -m app.services.doc_ingestor docs/
+
+# 4. Run the service
+uvicorn app.main:app --port 8000
+
+# 5. Tunnel for GitHub webhook delivery
+ngrok http 8000
+
+# 6. Configure the webhook in your repo settings
+#    Payload URL: https://<ngrok>/webhooks/github
+#    Content type: application/json
+#    Secret: same as GITHUB_WEBHOOK_SECRET
+#    Events: Issues only
+```
+
+Full setup walk-through: [`docs/how-to.md`](docs/how-to.md).
+
+---
+
+## Testing
+
+```bash
+# Unit tests (mocked LLM, no API costs)
+pytest tests/ -q
+
+# Eval suite (real LLM calls; ~$0.01 per run)
+python -m tests.eval.run_eval --label my-experiment
+```
+
+- 147 unit tests covering webhook handling, LLM service, GitHub client, RAG retrieval, doc ingestion, metrics, and feedback.
+- Tests use an autouse `conftest.py` fixture that strips LLM env vars so the test suite is deterministic regardless of local `.env` contents.
+
+---
+
+## Tech
+
+Python · FastAPI · Pydantic · LangChain · ChromaDB · Anthropic Claude · Google Gemini · httpx · pytest
 
 ---
 
 ## Author
 
-**Hanna Hunde**
-*Software Engineer | Aspiring AI Engineer*
+**Hanna Hunde** — Software Engineer

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,13 @@ import json
 import logging
 import os
 
+# Load .env before any other app imports so env vars are available everywhere.
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
 from fastapi import FastAPI, Header, HTTPException, Request
 from pydantic import BaseModel
 

--- a/app/services/doc_ingestor.py
+++ b/app/services/doc_ingestor.py
@@ -3,12 +3,26 @@
 Run directly::
 
     python -m app.services.doc_ingestor docs/
-    # or via env var:
     DOCS_DIR=docs/ python -m app.services.doc_ingestor
 
-Only Markdown (``*.md``) and plain-text (``*.txt``) files are indexed.
-Each file is split into overlapping chunks before embedding so that long
-documents don't exceed the model's context window.
+Chunking strategy
+-----------------
+Markdown files are split with a two-stage strategy that respects document
+structure rather than chopping by fixed character counts:
+
+1. ``MarkdownHeaderTextSplitter`` first splits a file on its ``#``, ``##``
+   and ``###`` headings, so each section stays in one chunk. The heading
+   path (e.g. *"Environment Variables > LOG_FORMAT"*) is preserved as
+   metadata.
+2. ``RecursiveCharacterTextSplitter`` then splits any oversized section by
+   paragraph → sentence → word boundaries, preferring natural breaks.
+
+Plain text files (``*.txt``) skip stage 1 and use only the recursive
+splitter. Each emitted chunk carries ``filename``, ``path``, ``chunk``,
+and (for Markdown) ``heading_path`` metadata.
+
+The legacy ``_chunk_text`` helper is retained for backwards-compatible
+imports but is no longer used by ``ingest_directory``.
 """
 
 from __future__ import annotations
@@ -16,6 +30,12 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from typing import Any
+
+from langchain_text_splitters import (
+    MarkdownHeaderTextSplitter,
+    RecursiveCharacterTextSplitter,
+)
 
 from app.services.retrieval_service import embed_documents
 
@@ -25,9 +45,136 @@ _CHUNK_SIZE = 512
 _CHUNK_OVERLAP = 50
 _SUPPORTED_EXTENSIONS = {".md", ".txt"}
 
+_HEADERS_TO_SPLIT_ON = [
+    ("#", "h1"),
+    ("##", "h2"),
+    ("###", "h3"),
+]
+
+_md_header_splitter = MarkdownHeaderTextSplitter(
+    headers_to_split_on=_HEADERS_TO_SPLIT_ON,
+    strip_headers=False,
+)
+
+_recursive_splitter = RecursiveCharacterTextSplitter(
+    chunk_size=_CHUNK_SIZE,
+    chunk_overlap=_CHUNK_OVERLAP,
+    separators=["\n\n", "\n", ". ", " ", ""],
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def ingest_directory(docs_path: str | Path) -> int:
+    """Index all supported files under *docs_path*. Returns chunk count."""
+    root = Path(docs_path)
+    if not root.is_dir():
+        raise ValueError(f"Not a directory: {docs_path}")
+
+    total_chunks = 0
+    for file_path in sorted(root.rglob("*")):
+        ext = file_path.suffix.lower()
+        if ext not in _SUPPORTED_EXTENSIONS:
+            continue
+
+        text = file_path.read_text(encoding="utf-8", errors="ignore")
+        if not text.strip():
+            continue
+
+        relative = file_path.relative_to(root)
+        if ext == ".md":
+            chunks, metadatas = _split_markdown(text, file_path, relative)
+        else:
+            chunks, metadatas = _split_plain_text(text, file_path, relative)
+
+        if not chunks:
+            continue
+
+        ids = [f"{relative}::{i}" for i in range(len(chunks))]
+        embed_documents(chunks, ids, metadatas)
+        total_chunks += len(chunks)
+        logger.info("Indexed %s -> %d chunk(s)", relative, len(chunks))
+
+    logger.info("Ingestion complete -- %d total chunk(s) from %s", total_chunks, root)
+    return total_chunks
+
+
+# ---------------------------------------------------------------------------
+# Splitting helpers
+# ---------------------------------------------------------------------------
+
+def _split_markdown(
+    text: str,
+    file_path: Path,
+    relative: Path,
+) -> tuple[list[str], list[dict[str, Any]]]:
+    """Two-stage split: headers first, then recursive on oversized sections."""
+    sections = _md_header_splitter.split_text(text)
+
+    chunks: list[str] = []
+    metadatas: list[dict[str, Any]] = []
+    for section in sections:
+        heading_path = _format_heading_path(section.metadata)
+        body = section.page_content
+        if len(body) <= _CHUNK_SIZE:
+            chunks.append(body)
+            metadatas.append(_make_metadata(file_path, relative, len(chunks) - 1, heading_path))
+        else:
+            # Section too long — split further with the recursive splitter.
+            sub_chunks = _recursive_splitter.split_text(body)
+            for sc in sub_chunks:
+                chunks.append(sc)
+                metadatas.append(_make_metadata(file_path, relative, len(chunks) - 1, heading_path))
+
+    return chunks, metadatas
+
+
+def _split_plain_text(
+    text: str,
+    file_path: Path,
+    relative: Path,
+) -> tuple[list[str], list[dict[str, Any]]]:
+    """Use the recursive splitter only — plain text has no headings."""
+    chunks = _recursive_splitter.split_text(text)
+    metadatas = [
+        _make_metadata(file_path, relative, i, heading_path="")
+        for i in range(len(chunks))
+    ]
+    return chunks, metadatas
+
+
+def _format_heading_path(meta: dict[str, Any]) -> str:
+    """Render the H1>H2>H3 heading hierarchy as a single string for metadata."""
+    parts = [meta.get(level) for level in ("h1", "h2", "h3") if meta.get(level)]
+    return " > ".join(parts)
+
+
+def _make_metadata(
+    file_path: Path,
+    relative: Path,
+    chunk_index: int,
+    heading_path: str,
+) -> dict[str, Any]:
+    md: dict[str, Any] = {
+        "filename": file_path.name,
+        "path": str(relative),
+        "chunk": chunk_index,
+    }
+    if heading_path:
+        md["heading_path"] = heading_path
+    return md
+
+
+# ---------------------------------------------------------------------------
+# Legacy helper — kept for backwards compatibility with existing tests
+# ---------------------------------------------------------------------------
 
 def _chunk_text(text: str, chunk_size: int = _CHUNK_SIZE, overlap: int = _CHUNK_OVERLAP) -> list[str]:
-    """Split *text* into overlapping fixed-size character chunks."""
+    """Fixed-size character chunker. Retained for legacy callers; new
+    ingestion uses structure-aware splitting via ``ingest_directory``.
+    """
     if not text.strip():
         return []
     chunks: list[str] = []
@@ -39,33 +186,9 @@ def _chunk_text(text: str, chunk_size: int = _CHUNK_SIZE, overlap: int = _CHUNK_
     return chunks
 
 
-def ingest_directory(docs_path: str | Path) -> int:
-    """Index all supported files under *docs_path*.
-
-    Returns the number of chunks indexed.
-    """
-    root = Path(docs_path)
-    if not root.is_dir():
-        raise ValueError(f"Not a directory: {docs_path}")
-
-    total_chunks = 0
-    for file_path in sorted(root.rglob("*")):
-        if file_path.suffix.lower() not in _SUPPORTED_EXTENSIONS:
-            continue
-        text = file_path.read_text(encoding="utf-8", errors="ignore")
-        chunks = _chunk_text(text)
-        if not chunks:
-            continue
-        relative = file_path.relative_to(root)
-        ids = [f"{relative}::{i}" for i in range(len(chunks))]
-        metadatas = [{"filename": file_path.name, "path": str(relative), "chunk": i} for i in range(len(chunks))]
-        embed_documents(chunks, ids, metadatas)
-        total_chunks += len(chunks)
-        logger.info("Indexed %s → %d chunk(s)", relative, len(chunks))
-
-    logger.info("Ingestion complete — %d total chunk(s) from %s", total_chunks, root)
-    return total_chunks
-
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
     import sys

--- a/app/services/issue_processor.py
+++ b/app/services/issue_processor.py
@@ -8,11 +8,21 @@ from app.services.metrics import metrics, track_triage_duration
 logger = logging.getLogger(__name__)
 
 
+def _llm_credentials_present() -> bool:
+    """Return True when the active LLM_PROVIDER has its API key set in env."""
+    provider = os.getenv("LLM_PROVIDER", "anthropic").lower()
+    if provider == "gemini":
+        return bool(os.getenv("GOOGLE_API_KEY"))
+    if provider == "anthropic":
+        return bool(os.getenv("ANTHROPIC_API_KEY"))
+    return False
+
+
 def triage_issue(repo_name: str, issue_number: int, title: str, body: str) -> TriageResult:
     """Triage a GitHub issue.
 
     1. Retrieve relevant context from the RAG vector store (if available).
-    2. Use the LLM with that context when ANTHROPIC_API_KEY is set.
+    2. Use the LLM with that context when the active provider's API key is set.
     3. Fall back to keyword-based heuristics on any error or missing key.
     4. Index the completed triage result for future RAG retrieval.
     5. Record metrics.
@@ -24,7 +34,7 @@ def triage_issue(repo_name: str, issue_number: int, title: str, body: str) -> Tr
 
     with track_triage_duration() as timing:
         try:
-            if os.getenv("ANTHROPIC_API_KEY"):
+            if _llm_credentials_present():
                 try:
                     result = classify_with_llm(repo_name, issue_number, title, body, context=context)
                     used_llm = True

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -42,13 +42,16 @@ class TriageOutput(BaseModel):
         description="The nature of the issue."
     )
     priority: Literal["High", "Medium", "Low"] = Field(
-        description="Urgency level based on impact and severity."
+        default="Medium",
+        description="Urgency level based on impact and severity.",
     )
     suggested_labels: list[str] = Field(
-        description="GitHub labels to apply (e.g. 'bug', 'priority-high')."
+        default_factory=list,
+        description="GitHub labels to apply (e.g. 'bug', 'priority-high').",
     )
     reason: str = Field(
-        description="One or two sentences explaining the triage decision."
+        default="(no reason provided)",
+        description="One or two sentences explaining the triage decision.",
     )
 
 

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -1,24 +1,33 @@
 """LangChain-based LLM triage pipeline.
 
 Chain structure:
-  ChatPromptTemplate (system + human) → ChatAnthropic.with_structured_output(TriageOutput)
+  ChatPromptTemplate (system + human) → <LLM provider>.with_structured_output(TriageOutput)
 
-The prompt is rendered with {repo}, {title}, {body}, {context} and piped into
-ChatAnthropic, which calls a structured-output tool and returns a TriageOutput
-Pydantic object directly. That is then mapped to the TriageResult domain model.
+The LLM provider is selected via the LLM_PROVIDER env var:
+  - "anthropic" (default) → ChatAnthropic, needs ANTHROPIC_API_KEY
+  - "gemini" → ChatGoogleGenerativeAI, needs GOOGLE_API_KEY
 
 LangSmith tracing is automatic when LANGCHAIN_TRACING_V2=true and
-LANGCHAIN_API_KEY are set — no extra code required.
+LANGCHAIN_API_KEY are set.
 """
 import logging
 import os
 from typing import Literal
 
 from langchain_anthropic import ChatAnthropic
+from langchain_core.language_models import BaseChatModel
 from langchain_core.prompts import ChatPromptTemplate
 from pydantic import BaseModel, Field
 
 from app.models.triage import TriageResult
+
+# Load .env automatically so `LLM_PROVIDER`, `GOOGLE_API_KEY`, etc. are
+# available even when running uvicorn from any cwd.
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +74,41 @@ _PROMPT = ChatPromptTemplate.from_messages([
 
 
 # ---------------------------------------------------------------------------
+# Provider selection
+# ---------------------------------------------------------------------------
+
+_DEFAULT_ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
+_DEFAULT_GEMINI_MODEL = "gemini-2.5-flash"
+
+
+def _get_llm(api_key: str | None = None, model: str | None = None) -> BaseChatModel:
+    """Pick the LLM provider based on LLM_PROVIDER env var.
+
+    Supported: 'anthropic' (default), 'gemini'.
+    """
+    provider = os.getenv("LLM_PROVIDER", "anthropic").lower()
+
+    if provider == "gemini":
+        from langchain_google_genai import ChatGoogleGenerativeAI
+        return ChatGoogleGenerativeAI(
+            model=model or os.getenv("GEMINI_MODEL") or _DEFAULT_GEMINI_MODEL,
+            google_api_key=api_key or os.getenv("GOOGLE_API_KEY"),
+            max_output_tokens=512,
+        )
+
+    if provider == "anthropic":
+        return ChatAnthropic(
+            model=model or os.getenv("ANTHROPIC_MODEL") or _DEFAULT_ANTHROPIC_MODEL,
+            api_key=api_key or os.getenv("ANTHROPIC_API_KEY"),
+            max_tokens=512,
+        )
+
+    raise ValueError(
+        f"Unknown LLM_PROVIDER='{provider}'. Use 'anthropic' or 'gemini'."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Public function
 # ---------------------------------------------------------------------------
 
@@ -76,18 +120,15 @@ def classify_with_llm(
     *,
     context: str = "",
     api_key: str | None = None,
-    model: str = "claude-haiku-4-5-20251001",
+    model: str | None = None,
 ) -> TriageResult:
-    """Classify a GitHub issue using a LangChain → Claude pipeline.
+    """Classify a GitHub issue using a LangChain → LLM pipeline.
 
-    Raises on any API or validation error (caller handles fallback).
-    LangSmith tracing is automatic when LANGCHAIN_TRACING_V2=true.
+    Provider is selected via LLM_PROVIDER env var. Raises on any API or
+    validation error (caller handles fallback). LangSmith tracing is
+    automatic when LANGCHAIN_TRACING_V2=true.
     """
-    llm = ChatAnthropic(
-        model=model,
-        api_key=api_key or os.getenv("ANTHROPIC_API_KEY"),
-        max_tokens=512,
-    )
+    llm = _get_llm(api_key=api_key, model=model)
 
     # Build the chain: prompt | model with structured output
     chain = _PROMPT | llm.with_structured_output(TriageOutput)

--- a/docs/project_spec.md
+++ b/docs/project_spec.md
@@ -1,97 +1,133 @@
-Github Issue Triage Project Specification
-==============================  
+# GitHub Issue Triage — Project Specification
 
-**Project Overview**:  
-    This project implements an AI-powered GitHub Issue Triage system that automatically analyzes newly created GitHub issues and assists maintainers by classifying, prioritizing, and labeling issues.
+## Overview
 
-   The system integrates:- 
-   - GitHub Webhooks
-   - A Python backend service
-   - Large Language Models (LLMs)
-   - Retrieval-Augmented Generation (RAG) for contextual triage
-   
-   The system processes GitHub issue events in real time and posts triage recommendations directly on the issue.
-   
-**Primary Goals**:
-1. **Automated Issue Analysis**: Automatically analyze the content of new GitHub issues to determine their nature, severity, and required expertise.
-2. **Contextual Triage**: Use RAG to retrieve relevant information from the repository (e.g., past issues, documentation) to provide context-aware triage recommendations.
-3. **Seamless GitHub Integration**: Integrate with GitHub using webhooks to receive issue events and post triage results directly on the issue.
-4. **Classifies issues into Categories**:
-   - Bug
-   - Feature Request
-   - Documentation
-   - Question
-   - Other
-5. **Prioritizes Issues**:
-   - High Priority
-   - Medium Priority
-   - Low Priority
-6. **Labels Issues**: Automatically apply relevant labels based on the analysis (e.g., "bug", "enhancement", "help wanted").
-7. **User Feedback Loop**: Allow maintainers to provide feedback on the triage results to continuously improve the model's accuracy.
+A FastAPI service that listens to GitHub webhook events and automatically classifies, prioritizes, and labels newly created issues. The triage decision is made by an LLM with retrieval-augmented context from the repository's own documentation, and the result is applied directly to the issue via the GitHub API.
 
-**Technical Stack**:
-- **Backend**: Python (Flask or FastAPI)
-- **LLM**: OpenAI GPT-4 or Anthropic Claude
-- **RAG**: Custom implementation using vector databases (e.g., Pinecone, ChromaDB)
-- **GitHub Integration**: GitHub Webhooks and API
-- **Deployment**: Docker, AWS Lambda or Heroku
-- **Other Tools**: ngrok for local development, GitHub Actions for CI/CD
-- **Data Sources**: GitHub issues, repository documentation, past issue history
+The system is designed for production deployment: signature-verified webhooks, multi-provider LLM abstraction, persistent RAG storage, structured logging, and an in-process metrics surface for observability.
 
-**High Level Workflow**:
+---
 
-    GitHub Repository
-            │
-            ▼
-    GitHub Webhook
-            │
-            ▼
-    FastAPI Backend Service
-            │
-            ├── Issue Processor
-            ├── LLM Service
-            ├── Retrieval Service (RAG)
-            └── GitHub Client
-            │
-            ▼
-    GitHub API
+## Goals
 
-**Core Workflow Steps**:
-1. **Issue Creation**: A new issue is created in the GitHub repository.
-2. **Webhook Trigger**: The GitHub webhook sends an event to the backend service with the issue details.
-3. **Issue Processing**: The backend service processes the issue content and extracts relevant information (e.g., title, description, labels).
-4. **Context Retrieval**: The RAG component retrieves relevant information from the repository (e.g., similar past issues, documentation) to provide context for the triage.
-5. **LLM Analysis**: The LLM analyzes the issue content along with the retrieved context to classify, prioritize, and label the issue.
-6. **Structured Output**: The LLM generates a structured output containing the issue category, priority level, and recommended labels.
-7. **Apply Labels**: The backend service uses the GitHub API to apply the recommended labels to the issue.
-8. **Post Triage Comment**: The backend service posts a comment on the issue with the triage results and recommendations for maintainers.
-9. **Feedback Loop**: Maintainers can provide feedback on the triage results, which is used to fine-tune the model and improve future triage accuracy.
+1. **Automated classification** of issues into Bug, Feature Request, Documentation, Question, or Other.
+2. **Priority inference** at High, Medium, or Low.
+3. **Label suggestions** that respect the repository's existing conventions (via RAG over docs and past issues).
+4. **Documented integration** that any maintainer can stand up in under 30 minutes.
+5. **Measurable triage quality** through a hand-crafted eval suite that produces comparable scorecards between configurations.
 
-**Future Enhancements**:
-- **Predictive Triage**: Use historical data to predict the likelihood of an issue being resolved within a certain timeframe.
-- **Multi-Language Support**: Extend the system to support issues in multiple languages.
-- **Performance metrics**: Implement metrics to evaluate the accuracy and effectiveness of the triage system (e.g., precision, recall, F1 score).
+---
 
-**Phase Based Implementation**:
-1. **Phase 1**: Infrastructure 
-   - FastAPI backend setup
-   - GitHub webhook integration
-   - Basic issue processing and logging
-   - payload parsing and validation
-   - Github API client implementation
-2. **Phase 2**: LLM Integration
-    - LLM integration for issue classification and labeling
-    - Priority prediction implementation
-    - Label suggestion implementation
-    - Triage comment generation
-3. **Phase 3**: RAG Implementation
-    - Embed repository docs
-    - Store embeddings in vector database
-    - Retrieve similar past issues and documentation for context
-    - Provide retrieved context for triage
-4. **Phase 4**: Evaluation and Observability
-    - Implement logging and monitoring
-    - Collect feedback from maintainers
-    - Evaluate triage accuracy and performance metrics
-    - Error Monitoring and Alerting
+## Architecture
 
+```
+GitHub Repository
+        │
+        ▼ (webhook on issue opened — HMAC-SHA256 signed)
+FastAPI Backend
+        │
+        ├── Issue Processor
+        │       ├── RAG Retrieval (ChromaDB)
+        │       ├── LLM Service (LangChain → Anthropic | Gemini)
+        │       │     └── Keyword fallback (always available)
+        │       └── Metrics (latency, counts, errors)
+        │
+        └── GitHub Client
+                ├── Auto-create labels with default colors
+                ├── Apply labels to the issue
+                └── Post formatted triage comment
+```
+
+Every external dependency (LLM, vector store, GitHub API) has a failure path. The webhook handler never returns a 5xx for an internal error — failures are logged and counted; triage either falls back to keyword matching or completes without the GitHub side-effects.
+
+---
+
+## Implementation by phase
+
+The project was built in four phases. All four are complete.
+
+### Phase 1 — Infrastructure
+- FastAPI service with `/health`, `/webhooks/github`, `/metrics`, `/feedback/{owner}/{repo}/{issue}`.
+- HMAC-SHA256 signature verification gated on `GITHUB_WEBHOOK_SECRET`.
+- Payload parsing with strict validation (rejects missing/malformed fields).
+- `GitHubClient` for label auto-creation, label application, and triage-comment posting; uses `httpx.Client` for testability.
+- Structured logging (`text` or `json` via `LOG_FORMAT`).
+
+### Phase 2 — LLM integration
+- LangChain pipeline: `ChatPromptTemplate | <provider>.with_structured_output(TriageOutput)`.
+- Two providers: Anthropic Claude and Google Gemini, swapped via `LLM_PROVIDER`. Model overrides via `ANTHROPIC_MODEL` / `GEMINI_MODEL`.
+- Structured output via Pydantic schema with safe defaults for fields some models occasionally omit.
+- Optional LangSmith tracing — auto-enabled when `LANGCHAIN_TRACING_V2=true`.
+- Keyword fallback path preserved as the default when no API key is configured or the LLM call raises.
+
+### Phase 3 — RAG
+- ChromaDB vector store with two collections: `docs` (ingested at startup or via CLI) and `issues` (streamed in as triage runs).
+- `python -m app.services.doc_ingestor docs/` builds the docs collection.
+- **Chunking strategy:** structure-aware. `MarkdownHeaderTextSplitter` preserves section boundaries; `RecursiveCharacterTextSplitter` handles oversized sections by preferring paragraph and sentence breaks. Heading hierarchy (e.g. *"Reference > Environment Variables"*) is stored as chunk metadata.
+- Retrieval surfaces the top-N most similar chunks across both collections, truncated to 1.5KB before being injected into the LLM prompt.
+
+### Phase 4 — Evaluation & Observability
+- `TriageMetrics` singleton: counts, LLM-vs-fallback split, errors, per-category and per-priority breakdowns, avg latency, feedback verdict counts.
+- `/metrics` endpoint exposes the full snapshot as JSON.
+- `/feedback` endpoint records maintainer verdicts (`correct`, `incorrect`, `overridden`).
+- **Eval suite** (`tests/eval/`):
+  - 10 labeled scenarios (4 generic triage-quality, 6 doc-grounded for RAG-quality).
+  - Standalone runner that resets the vector store, re-ingests docs, runs each case, scores against expected outputs, and saves timestamped JSON for run-over-run comparison.
+  - Scores: category accuracy, priority accuracy, label F1, retrieval keyword hit-rate.
+
+---
+
+## Eval methodology
+
+Each case in `tests/eval/cases.yaml` specifies the issue payload plus expected triage and retrieval outputs:
+
+```yaml
+- id: q_json_logging_env_var
+  title: "How do I get JSON-formatted logs for production?"
+  body: |
+    Running this in Kubernetes, our log aggregator expects JSON. What env
+    var do I set?
+  expected:
+    triage:
+      category: Question
+      priority: Low
+    retrieval:
+      must_retrieve_from: [how-to.md]
+      expected_keywords_in_context: [LOG_FORMAT]
+```
+
+The runner records both the triage decision and the retrieved RAG context, then scores them independently. Results land in `tests/eval/results/{timestamp}-{label}.json` so two configurations can be compared directly.
+
+This separation matters: triage quality reflects the LLM, retrieval quality reflects the chunking and embedding strategy. Mixing them obscures which knob is doing the work.
+
+---
+
+## Tech stack
+
+- **Backend:** Python 3.10+, FastAPI, Pydantic v2
+- **LLM orchestration:** LangChain (`langchain-anthropic`, `langchain-google-genai`)
+- **Vector store:** ChromaDB with default sentence-transformer embeddings
+- **Text splitting:** `langchain-text-splitters` (`MarkdownHeaderTextSplitter`, `RecursiveCharacterTextSplitter`)
+- **HTTP:** httpx for GitHub API; uvicorn for the ASGI server
+- **Testing:** pytest, pytest-asyncio
+- **Observability:** structured logging, in-process metrics, optional LangSmith tracing
+
+---
+
+## Future enhancements
+
+| Area | Idea | Why |
+|---|---|---|
+| Persistent storage | Migrate `CHROMA_DB_PATH` to PostgreSQL + pgvector | Production-ready storage; replication and backups for free |
+| Embedding model | Move from default MiniLM to `text-embedding-005` or similar | Better semantic similarity on technical docs |
+| Eval coverage | Grow to 50+ cases sourced from real triaged issues across multiple repos | Smaller per-case noise dominates the aggregate at N=10 |
+| Multi-run scoring | Average each case over N runs to separate chunking signal from LLM stochasticity | More confident A/B claims |
+| Duplicate detection | Use the `issues` collection to flag potential duplicates in the triage comment | High-leverage feature for busy repos |
+| Confidence scoring | Have the LLM emit a confidence value; route low-confidence triages to human review | Improves trust and feedback signal |
+| Multi-tenancy | Scope retrieval by `repo` metadata for a shared deployment serving many repos | Required for a hosted product offering |
+
+---
+
+## Status
+
+Production-ready as a self-hosted service for a single repository. The pipeline has been exercised end-to-end against real Gemini API calls with all four phases and the eval suite producing reproducible scorecards.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "langchain-anthropic>=0.3.0",
     "langchain-core>=0.3.0",
     "langchain-google-genai>=2.0.0",
+    "langchain-text-splitters>=0.3.0",
     "chromadb>=0.6.0",
     "fastapi>=0.129.0",
     "httpx>=0.28.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "python-dotenv>=1.2.1",
+    "pyyaml>=6.0",
     "ruff>=0.15.1",
     "uvicorn[standard]>=0.41.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "anthropic>=0.49.0",
     "langchain-anthropic>=0.3.0",
     "langchain-core>=0.3.0",
+    "langchain-google-genai>=2.0.0",
     "chromadb>=0.6.0",
     "fastapi>=0.129.0",
     "httpx>=0.28.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Pytest configuration.
+
+Strips LLM provider env vars before every test so the unit test suite
+exercises the keyword-fallback path deterministically, regardless of
+what's in the developer's local `.env`.
+
+Tests that DO want the LLM path active mock `_get_llm` directly (see
+tests/test_llm_service.py), so they're unaffected.
+
+The eval runner (tests/eval/run_eval.py) is invoked outside pytest, so
+this fixture doesn't apply there.
+"""
+import os
+
+import pytest
+
+
+_LLM_ENV_VARS = (
+    "LLM_PROVIDER",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_MODEL",
+    "GOOGLE_API_KEY",
+    "GEMINI_MODEL",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_llm_env(monkeypatch):
+    """Unset all LLM-related env vars for the duration of every test."""
+    for var in _LLM_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -1,0 +1,106 @@
+# Eval Suite
+
+Measures triage quality on a hand-crafted set of issue scenarios. Used to
+compare implementations (e.g. fixed vs semantic chunking) by running the
+same cases against each variant and diffing the scorecards.
+
+## What's in here
+
+- `cases.yaml` — 10 labeled issue scenarios with expected triage decisions
+  and (for doc-grounded cases) expected retrieval keywords
+- `run_eval.py` — the runner; ingests docs, runs each case, scores, prints
+  a scorecard, and saves results to `results/{ts}-{label}.json`
+- `results/` — historical run output (gitignored — these are local
+  measurements, not artifacts)
+
+## Running
+
+```bash
+# Quick run with default settings
+python -m tests.eval.run_eval
+
+# Tag the run so you can compare later
+python -m tests.eval.run_eval --label fixed-chunking-baseline
+
+# Custom paths
+python -m tests.eval.run_eval --cases tests/eval/cases.yaml --docs docs/
+```
+
+The eval uses whichever LLM provider is configured in `.env`
+(`LLM_PROVIDER=anthropic` or `gemini`). It will call the real API and
+spend real credits. Typically ~$0.01–$0.05 per full run.
+
+## Cases.yaml schema
+
+```yaml
+- id: unique_id                # stable identifier
+  title: "Issue title"
+  body: |
+    Multi-line issue body.
+  expected:
+    triage:
+      # Either exact match...
+      category: Bug             # one of: Bug, Feature Request, Documentation, Question, Other
+      priority: High            # one of: High, Medium, Low
+      # ...or accept a list:
+      category_acceptable: [Bug, Documentation]
+      priority_acceptable: [Low, Medium]
+      # Label constraints (all optional):
+      must_have_labels: [bug, priority-high]
+      must_not_have_labels: [feature-request]
+      must_have_labels_any_of: [bug, documentation]
+    # Optional — for doc-grounded cases that test retrieval quality
+    retrieval:
+      must_retrieve_from: [how-to.md]   # advisory only (not scored in v1)
+      expected_keywords_in_context:      # scored — checks these strings
+        - GITHUB_WEBHOOK_SECRET           # appear in the retrieved context
+        - HMAC
+  notes: "Human-readable explanation of why this case exists"
+```
+
+## Scoring
+
+Each case yields up to four sub-scores (each 0–1):
+
+| Score | What it measures |
+|---|---|
+| `category` | 1 if `result.category` matches `expected.triage.category` (or is in `category_acceptable`), else 0 |
+| `priority` | Same logic for priority |
+| `labels` | Fraction of label constraints satisfied (must-have, must-not-have, any-of) |
+| `retrieval` | Fraction of `expected_keywords_in_context` that appear in the retrieved RAG context (case-insensitive substring match) |
+
+The scorecard prints:
+
+- Per-case pass/fail on each dimension
+- Aggregate pass-rates across all cases
+- A "failures" section listing every case that wasn't perfect, with reasons
+- Average latency for retrieval and LLM stages
+
+## Comparing runs
+
+After running with two different labels, the JSON output files have
+identical structure, so you can diff them:
+
+```bash
+python -m tests.eval.run_eval --label baseline
+# ...refactor chunking...
+python -m tests.eval.run_eval --label semantic-chunking
+
+# Compare manually, or write a small diff script
+diff <(jq .summary tests/eval/results/*-baseline.json) \
+     <(jq .summary tests/eval/results/*-semantic-chunking.json)
+```
+
+## What this eval IS measuring
+
+- Whether the LLM makes correct category / priority / label decisions
+- Whether RAG retrieval surfaces the right context (via keyword presence)
+- End-to-end latency
+
+## What this eval is NOT measuring
+
+- Webhook signature verification (covered by unit tests)
+- GitHub API integration (covered by unit tests, validate manually with ngrok)
+- Behavior under high load (use a load testing tool)
+- Anything about the `issues` collection (we'd need real past-issue data;
+  not relevant to the docs-chunking refactor)

--- a/tests/eval/cases.yaml
+++ b/tests/eval/cases.yaml
@@ -1,0 +1,192 @@
+# Eval suite: 10 hand-crafted issue scenarios.
+#
+# Each case lists the issue payload, what the triage decision *should* be, and
+# (where relevant) which doc the retrieval *should* have pulled. Used by
+# tests/eval/run_eval.py — these are NOT run by pytest.
+#
+# Sources:
+#   1-4   from our manual smoke test conversation (Gemini's actual responses
+#         on these inputs looked reasonable, so we treat them as reference)
+#   5-10  doc-grounded: the answer to each question lives in a specific
+#         section of a specific .md file, so we can measure whether the
+#         chunking + retrieval surfaced the right context.
+
+# ─────────────────────────────────────────────────────────────────────
+# Group 1 — Triage-quality cases (no retrieval requirement)
+# These exercise pure LLM judgment. They have no `retrieval` block
+# because they don't require docs to triage correctly.
+# ─────────────────────────────────────────────────────────────────────
+
+- id: bug_npe_blocking_release
+  title: "App crashes on startup with NullPointerException"
+  body: |
+    Getting a NPE when I run the app. Traceback shows it is happening in the
+    auth module. This is blocking our release tomorrow.
+  expected:
+    triage:
+      category: Bug
+      priority: High
+      must_have_labels: [bug, priority-high]
+      must_not_have_labels: [feature-request, question]
+  notes: "Classic high-priority bug with clear keywords."
+
+- id: feature_dark_mode
+  title: "Would love dark mode support"
+  body: |
+    My eyes hurt at night when using the dashboard. Could we add a theme toggle?
+  expected:
+    triage:
+      category: Feature Request
+      priority_acceptable: [Low, Medium]
+      must_have_labels: [feature-request]
+      must_not_have_labels: [bug, priority-high]
+  notes: "Quality-of-life feature request, no urgency signal."
+
+- id: vague_complaint
+  title: "This thing isn't great"
+  body: |
+    It just kind of works but I dont like how it feels.
+  expected:
+    triage:
+      category_acceptable: [Question, Other]
+      priority: Low
+      must_have_labels: [needs-info]
+      must_not_have_labels: [bug, priority-high]
+  notes: "Tests that the LLM asks for more info instead of guessing."
+
+- id: ambiguous_readme_wrong
+  title: "README install section is wrong"
+  body: |
+    The npm install command in the README points to an old package name.
+    New installations fail with this command.
+  expected:
+    triage:
+      # Both are defensible — broken docs vs broken UX. We accept either.
+      category_acceptable: [Bug, Documentation]
+      priority_acceptable: [Medium, High]
+      must_have_labels_any_of: [bug, documentation]
+  notes: |
+    Tests handling of an ambiguous case. There's no single "right" answer —
+    a maintainer could classify this either way. The eval accepts either,
+    but flags it if a future change makes the system pick something wild.
+
+# ─────────────────────────────────────────────────────────────────────
+# Group 2 — Doc-grounded cases (test retrieval quality)
+# Each case poses a question whose answer lives in a specific section
+# of a specific .md file. The eval checks BOTH the triage decision
+# AND whether retrieval surfaced the right doc.
+# ─────────────────────────────────────────────────────────────────────
+
+- id: q_webhook_signature_verification
+  title: "How do I verify webhook signatures coming from GitHub?"
+  body: |
+    I want to make sure the webhook requests are really coming from GitHub
+    and not from someone spoofing them. How does this app handle that?
+  expected:
+    triage:
+      category: Question
+      priority_acceptable: [Low, Medium]
+    retrieval:
+      # Answer lives in how-to.md sections 2 (env var) and 5 (webhook config)
+      must_retrieve_from: [how-to.md]
+      expected_keywords_in_context:
+        - GITHUB_WEBHOOK_SECRET
+  notes: |
+    Tests that doc retrieval pulls the section explaining HMAC-SHA256
+    signature verification with the GITHUB_WEBHOOK_SECRET env var.
+
+- id: q_json_logging_env_var
+  title: "How do I get JSON-formatted logs for production?"
+  body: |
+    Running this in Kubernetes, our log aggregator expects JSON. What env
+    var do I set?
+  expected:
+    triage:
+      category: Question
+      priority: Low
+    retrieval:
+      # Answer is LOG_FORMAT=json, in how-to.md section 2 + env var table
+      must_retrieve_from: [how-to.md]
+      expected_keywords_in_context:
+        - LOG_FORMAT
+  notes: |
+    The answer (LOG_FORMAT=json) sits in the env var reference table at
+    the bottom of how-to.md. Tests whether chunking preserves the table
+    rows together.
+
+- id: q_docs_ingestion_command
+  title: "How do I ingest my repository's docs into the RAG store?"
+  body: |
+    I want the LLM to have context from our internal documentation when it
+    triages. What's the command or env var for that?
+  expected:
+    triage:
+      category: Question
+      priority: Low
+    retrieval:
+      # Answer in how-to.md section 7
+      must_retrieve_from: [how-to.md]
+      expected_keywords_in_context:
+        - doc_ingestor
+        - DOCS_DIR
+  notes: |
+    Tests retrieval of the RAG ingestion section. Bonus: this section has
+    both a command line and an env var, so retrieval needs to pull either.
+
+- id: q_feedback_verdicts_meaning
+  title: "What do the different feedback verdicts mean?"
+  body: |
+    I see I can POST correct, incorrect, or overridden to /feedback — what's
+    the practical difference? When should I use which?
+  expected:
+    triage:
+      category: Question
+      priority: Low
+    retrieval:
+      must_retrieve_from: [how-to.md]
+      expected_keywords_in_context:
+        - overridden
+        - incorrect
+  notes: |
+    The verdicts table is in how-to.md section 9. Tests whether the table
+    survives the chunking process intact.
+
+- id: q_categories_supported
+  title: "What issue categories does the triage system produce?"
+  body: |
+    Trying to set up label colors in advance. What are the possible
+    categories the LLM will choose between?
+  expected:
+    triage:
+      category: Question
+      priority: Low
+    retrieval:
+      must_retrieve_from: [project_spec.md]
+      expected_keywords_in_context:
+        - Bug
+        - Feature Request
+        - Documentation
+        - Question
+  notes: |
+    The 5 categories are listed in project_spec.md under "Primary Goals".
+    Tests retrieval across docs (not just how-to.md).
+
+- id: bug_metrics_endpoint_404
+  title: "GET /metrics returns 404 in production"
+  body: |
+    The /metrics endpoint works locally but returns 404 when I deploy to
+    production behind nginx. The README says this endpoint should exist.
+    Is there a config flag I'm missing?
+  expected:
+    triage:
+      category_acceptable: [Bug, Question]
+      priority_acceptable: [Medium, High]
+      must_have_labels_any_of: [bug, question, needs-info]
+    retrieval:
+      # README mentions /metrics in the API endpoint table
+      must_retrieve_from: [README.md, how-to.md]
+      expected_keywords_in_context:
+        - /metrics
+  notes: |
+    A realistic mixed case — could be a bug, could be a config question.
+    Tests retrieval across both top-level README and how-to.md.

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -1,0 +1,350 @@
+"""Eval runner for the triage pipeline.
+
+Loads cases.yaml, runs each through the LLM + RAG pipeline against the
+real docs ingested into a fresh vector store, scores the responses, and
+prints a scorecard. Results are saved to tests/eval/results/{ts}.json so
+you can compare runs (e.g. before vs after a chunking refactor).
+
+NOT run by pytest — costs real LLM credits. Run explicitly:
+
+    python -m tests.eval.run_eval
+    python -m tests.eval.run_eval --label "fixed-chunking-baseline"
+    python -m tests.eval.run_eval --cases tests/eval/cases.yaml --docs docs/
+
+Exit code 0 always — this is a measurement tool, not a pass/fail test.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Load .env before importing app modules so LLM_PROVIDER, GOOGLE_API_KEY, etc. are visible
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+from app.services import retrieval_service
+from app.services.doc_ingestor import ingest_directory
+from app.services.llm_service import classify_with_llm
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Setup: reset vector store and re-ingest docs
+# ---------------------------------------------------------------------------
+
+def setup_vector_store(docs_path: Path) -> int:
+    """Reset the vector store and re-ingest docs. Returns chunks ingested."""
+    retrieval_service._reset_client()
+    # The reset gives us a fresh ephemeral client; collections are recreated empty.
+    n = ingest_directory(docs_path)
+    print(f"  Ingested {n} doc chunks from {docs_path}")
+    return n
+
+
+# ---------------------------------------------------------------------------
+# Per-case execution
+# ---------------------------------------------------------------------------
+
+def run_case(case: dict, repo: str = "eval/sandbox") -> dict:
+    """Run one case through retrieval + LLM. Returns raw outputs."""
+    title = case["title"]
+    body = case.get("body", "")
+
+    start = time.monotonic()
+    context = retrieval_service.get_context(title, body)
+    retrieve_ms = (time.monotonic() - start) * 1000
+
+    start = time.monotonic()
+    result = classify_with_llm(repo, 1, title, body, context=context)
+    llm_ms = (time.monotonic() - start) * 1000
+
+    return {
+        "context": context,
+        "context_chars": len(context),
+        "result": result.model_dump(),
+        "retrieve_ms": round(retrieve_ms, 1),
+        "llm_ms": round(llm_ms, 1),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def _score_category(expected: dict, actual: str) -> float | None:
+    if "category" in expected:
+        return 1.0 if actual == expected["category"] else 0.0
+    if "category_acceptable" in expected:
+        return 1.0 if actual in expected["category_acceptable"] else 0.0
+    return None
+
+
+def _score_priority(expected: dict, actual: str) -> float | None:
+    if "priority" in expected:
+        return 1.0 if actual == expected["priority"] else 0.0
+    if "priority_acceptable" in expected:
+        return 1.0 if actual in expected["priority_acceptable"] else 0.0
+    return None
+
+
+def _score_labels(expected: dict, actual_labels: list[str]) -> tuple[float, list[str]]:
+    """Return (score 0..1, list of failure descriptions)."""
+    checks: list[bool] = []
+    failures: list[str] = []
+    actual_set = set(actual_labels)
+
+    for required in expected.get("must_have_labels", []):
+        passed = required in actual_set
+        checks.append(passed)
+        if not passed:
+            failures.append(f"missing required label '{required}'")
+
+    for forbidden in expected.get("must_not_have_labels", []):
+        passed = forbidden not in actual_set
+        checks.append(passed)
+        if not passed:
+            failures.append(f"forbidden label '{forbidden}' was applied")
+
+    any_of = expected.get("must_have_labels_any_of")
+    if any_of:
+        passed = any(l in actual_set for l in any_of)
+        checks.append(passed)
+        if not passed:
+            failures.append(f"none of {any_of} present")
+
+    if not checks:
+        return 1.0, []
+    return sum(checks) / len(checks), failures
+
+
+def _score_retrieval(expected: dict, context: str) -> tuple[float | None, list[str]]:
+    """Score retrieval quality by keyword presence. Returns (score, failures)."""
+    if not expected:
+        return None, []
+    keywords = expected.get("expected_keywords_in_context", [])
+    if not keywords:
+        return None, []
+
+    failures: list[str] = []
+    hits = 0
+    ctx_lower = context.lower()
+    for kw in keywords:
+        if kw.lower() in ctx_lower:
+            hits += 1
+        else:
+            failures.append(f"keyword '{kw}' missing from retrieved context")
+
+    return hits / len(keywords), failures
+
+
+def score_case(case: dict, run_output: dict) -> dict:
+    """Return per-case score breakdown."""
+    expected = case.get("expected", {})
+    triage_exp = expected.get("triage", {})
+    retrieval_exp = expected.get("retrieval", {})
+
+    result = run_output["result"]
+
+    cat = _score_category(triage_exp, result["category"])
+    pri = _score_priority(triage_exp, result["priority"])
+    labels_score, label_failures = _score_labels(triage_exp, result["suggested_labels"])
+    retrieval_score, retrieval_failures = _score_retrieval(retrieval_exp, run_output["context"])
+
+    return {
+        "category": cat,
+        "priority": pri,
+        "labels": labels_score,
+        "label_failures": label_failures,
+        "retrieval": retrieval_score,
+        "retrieval_failures": retrieval_failures,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Scorecard
+# ---------------------------------------------------------------------------
+
+def print_scorecard(results: list[dict], label: str, model_info: dict) -> dict:
+    """Print aggregate scorecard. Returns a summary dict."""
+    n = len(results)
+
+    def _avg(scores: list[float | None]) -> float:
+        vals = [s for s in scores if s is not None]
+        return sum(vals) / len(vals) if vals else 0.0
+
+    cat_scores = [r["scores"]["category"] for r in results]
+    pri_scores = [r["scores"]["priority"] for r in results]
+    label_scores = [r["scores"]["labels"] for r in results]
+    retr_scores = [r["scores"]["retrieval"] for r in results]
+
+    cat_pass = sum(1 for s in cat_scores if s == 1.0)
+    pri_pass = sum(1 for s in pri_scores if s == 1.0)
+    retr_count = sum(1 for s in retr_scores if s is not None)
+    retr_full = sum(1 for s in retr_scores if s is not None and s == 1.0)
+
+    # Latency averages only over successful runs (error cases have no 'run' key)
+    successful = [r for r in results if "run" in r]
+    n_ok = len(successful)
+    avg_llm_ms = (sum(r["run"]["llm_ms"] for r in successful) / n_ok) if n_ok else 0
+    avg_retr_ms = (sum(r["run"]["retrieve_ms"] for r in successful) / n_ok) if n_ok else 0
+    n_errors = n - n_ok
+
+    summary = {
+        "label": label,
+        "model": model_info,
+        "n_cases": n,
+        "category_pass_rate": cat_pass / n,
+        "priority_pass_rate": pri_pass / n,
+        "labels_avg": _avg(label_scores),
+        "retrieval_avg": _avg(retr_scores),
+        "retrieval_full_match_rate": retr_full / retr_count if retr_count else 0.0,
+        "avg_llm_ms": round(avg_llm_ms, 1),
+        "avg_retrieve_ms": round(avg_retr_ms, 1),
+    }
+
+    print("\n" + "=" * 60)
+    print(f"  EVAL SCORECARD -- {label}")
+    print(f"  Provider={model_info['provider']}  Model={model_info['model']}")
+    print("=" * 60)
+    print(f"  Cases run: {n}  (errors: {n_errors})")
+    print(f"  Category accuracy: {cat_pass}/{n}  ({cat_pass * 100 / n:.0f}%)")
+    print(f"  Priority accuracy: {pri_pass}/{n}  ({pri_pass * 100 / n:.0f}%)")
+    print(f"  Label score (avg): {summary['labels_avg']:.2f}")
+    if retr_count:
+        print(f"  Retrieval keyword hit-rate (avg): {summary['retrieval_avg']:.2f}")
+        print(f"  Retrieval full-match: {retr_full}/{retr_count} cases hit ALL keywords")
+    print(f"  Avg retrieve latency: {summary['avg_retrieve_ms']:.0f} ms")
+    print(f"  Avg LLM latency:      {summary['avg_llm_ms']:.0f} ms")
+    print("=" * 60)
+
+    # Per-case failures
+    failed_cases = [
+        r for r in results
+        if r["scores"]["category"] != 1.0
+        or r["scores"]["priority"] != 1.0
+        or r["scores"]["labels"] != 1.0
+        or (r["scores"]["retrieval"] is not None and r["scores"]["retrieval"] != 1.0)
+    ]
+    error_cases = [r for r in results if "error" in r]
+    if error_cases:
+        print("\nCases that errored:")
+        for r in error_cases:
+            print(f"  - {r['case_id']}: {r['error'][:100]}")
+
+    if failed_cases:
+        print("\nCases with imperfect scores:")
+        for r in failed_cases:
+            if "error" in r:
+                continue  # already shown above
+            print(f"  - {r['case_id']}")
+            s = r["scores"]
+            if s["category"] not in (None, 1.0):
+                print(f"      category: got '{r['run']['result']['category']}'")
+            if s["priority"] not in (None, 1.0):
+                print(f"      priority: got '{r['run']['result']['priority']}'")
+            for f in s["label_failures"]:
+                print(f"      labels: {f}")
+            for f in s["retrieval_failures"]:
+                print(f"      retrieval: {f}")
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run triage eval suite.")
+    parser.add_argument("--cases", type=Path, default=Path("tests/eval/cases.yaml"))
+    parser.add_argument("--docs", type=Path, default=Path("docs"))
+    parser.add_argument("--label", type=str, default="run",
+                       help="Tag this run (e.g. 'fixed-chunking-baseline')")
+    parser.add_argument("--output-dir", type=Path,
+                       default=Path("tests/eval/results"))
+    args = parser.parse_args()
+
+    print(f"\n>> Eval starting -- label='{args.label}'")
+    print(f"  Cases: {args.cases}")
+    print(f"  Docs:  {args.docs}\n")
+
+    # Setup
+    print("Setting up vector store...")
+    n_chunks = setup_vector_store(args.docs)
+
+    # Load cases
+    with args.cases.open() as f:
+        cases = yaml.safe_load(f)
+    print(f"  Loaded {len(cases)} cases\n")
+
+    # Run each case
+    results = []
+    for i, case in enumerate(cases, 1):
+        print(f"[{i}/{len(cases)}] {case['id']}", flush=True)
+        try:
+            run_out = run_case(case)
+            scores = score_case(case, run_out)
+            results.append({
+                "case_id": case["id"],
+                "case_title": case["title"],
+                "run": run_out,
+                "scores": scores,
+            })
+            cat_ok = "[OK]" if scores["category"] == 1.0 else "[X] "
+            pri_ok = "[OK]" if scores["priority"] == 1.0 else "[X] "
+            print(f"    category={cat_ok}  priority={pri_ok}  labels={scores['labels']:.2f}", end="")
+            if scores["retrieval"] is not None:
+                print(f"  retrieval={scores['retrieval']:.2f}")
+            else:
+                print()
+        except Exception as exc:
+            logger.error("Case %s failed: %s", case["id"], exc, exc_info=True)
+            results.append({
+                "case_id": case["id"],
+                "case_title": case["title"],
+                "error": str(exc),
+                "scores": {"category": 0, "priority": 0, "labels": 0,
+                          "retrieval": 0, "label_failures": [], "retrieval_failures": []},
+            })
+
+    # Scorecard
+    import os
+    model_info = {
+        "provider": os.getenv("LLM_PROVIDER", "anthropic"),
+        "model": os.getenv("GEMINI_MODEL") or os.getenv("ANTHROPIC_MODEL") or "default",
+    }
+    summary = print_scorecard(results, args.label, model_info)
+
+    # Save
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+    out_path = args.output_dir / f"{ts}-{args.label}.json"
+    payload = {
+        "timestamp": ts,
+        "label": args.label,
+        "doc_chunks_indexed": n_chunks,
+        "summary": summary,
+        "results": results,
+    }
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)
+    print(f"\nResults saved to {out_path}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_doc_ingestor.py
+++ b/tests/test_doc_ingestor.py
@@ -1,4 +1,8 @@
-"""Tests for app.services.doc_ingestor."""
+"""Tests for app.services.doc_ingestor.
+
+Covers both the structure-aware Markdown chunking pipeline and the
+legacy fixed-size helper.
+"""
 
 import pytest
 
@@ -15,9 +19,8 @@ def reset_chroma(monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Chunking helper
+# Legacy fixed-size chunker (still exported for backwards compatibility)
 # ---------------------------------------------------------------------------
-
 
 def test_chunk_text_splits_long_text():
     text = "x" * 1000
@@ -32,9 +35,8 @@ def test_chunk_text_empty_returns_empty():
 
 
 # ---------------------------------------------------------------------------
-# ingest_directory
+# ingest_directory — happy paths
 # ---------------------------------------------------------------------------
-
 
 def test_ingest_indexes_md_files(tmp_path):
     (tmp_path / "guide.md").write_text("# Setup Guide\nRun pip install to get started.")
@@ -61,3 +63,88 @@ def test_ingest_skips_non_md_files(tmp_path):
 def test_ingest_raises_for_missing_directory():
     with pytest.raises(ValueError, match="Not a directory"):
         ingest_directory("/nonexistent/path/xyz")
+
+
+# ---------------------------------------------------------------------------
+# Structure-aware Markdown chunking
+# ---------------------------------------------------------------------------
+
+class TestStructureAwareChunking:
+    """The Markdown ingestor should split on headings, not arbitrary char counts."""
+
+    def test_short_sections_become_one_chunk_per_section(self, tmp_path):
+        md = (
+            "# Top Level\n\n"
+            "## Section A\n\n"
+            "Content for section A.\n\n"
+            "## Section B\n\n"
+            "Content for section B.\n"
+        )
+        (tmp_path / "doc.md").write_text(md)
+        ingest_directory(tmp_path)
+
+        col = rs._get_collection("docs")
+        records = col.get(include=["documents", "metadatas"])
+        docs = records["documents"]
+
+        # Each section's heading + content should land in a single chunk.
+        assert any("Section A" in d and "Content for section A" in d for d in docs)
+        assert any("Section B" in d and "Content for section B" in d for d in docs)
+
+    def test_heading_path_stored_in_metadata(self, tmp_path):
+        md = (
+            "# Setup Guide\n\n"
+            "## Environment Variables\n\n"
+            "Set `LOG_FORMAT=json` for structured logs.\n"
+        )
+        (tmp_path / "doc.md").write_text(md)
+        ingest_directory(tmp_path)
+
+        col = rs._get_collection("docs")
+        records = col.get(include=["metadatas"])
+        metadatas = records["metadatas"]
+
+        heading_paths = [m.get("heading_path", "") for m in metadatas]
+        assert any("Setup Guide" in hp and "Environment Variables" in hp for hp in heading_paths)
+
+    def test_table_like_section_stays_together(self, tmp_path):
+        """A short list/table should land in a single chunk, not be split mid-row."""
+        md = (
+            "# Reference\n\n"
+            "## Variables\n\n"
+            "| Var | Default | Description |\n"
+            "|---|---|---|\n"
+            "| `LOG_LEVEL` | INFO | Log verbosity |\n"
+            "| `LOG_FORMAT` | text | text or json |\n"
+            "| `DOCS_DIR` | - | Docs path |\n"
+        )
+        (tmp_path / "ref.md").write_text(md)
+        ingest_directory(tmp_path)
+
+        col = rs._get_collection("docs")
+        records = col.get(include=["documents"])
+        # The whole table should appear in a single chunk.
+        joined_chunks = records["documents"]
+        for chunk in joined_chunks:
+            if "LOG_FORMAT" in chunk:
+                assert "LOG_LEVEL" in chunk and "DOCS_DIR" in chunk
+                return
+        pytest.fail("No chunk contained the full env-var table")
+
+    def test_long_section_gets_subdivided(self, tmp_path):
+        """A section whose content exceeds the chunk size should be split further."""
+        long_body = "Paragraph " + ("alpha " * 200) + "\n\nParagraph " + ("beta " * 200)
+        md = f"# Long\n\n## Big Section\n\n{long_body}\n"
+        (tmp_path / "long.md").write_text(md)
+        ingest_directory(tmp_path)
+
+        col = rs._get_collection("docs")
+        records = col.get(include=["documents", "metadatas"])
+        # Should produce more than one chunk because the section exceeds 512 chars.
+        assert len(records["documents"]) > 1
+        # All sub-chunks should still carry the same heading path.
+        big_chunks = [
+            m for m in records["metadatas"]
+            if m.get("heading_path", "").endswith("Big Section")
+        ]
+        assert len(big_chunks) > 1

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -1,20 +1,23 @@
 """Tests for the LangChain-based LLM triage service.
 
-We mock the ChatAnthropic model so no real API calls are made.
+We mock _get_llm() so no real API calls are made. The chain is:
+  ChatPromptTemplate | llm.with_structured_output(TriageOutput)
 
-The chain is:  ChatPromptTemplate | ChatAnthropic.with_structured_output(TriageOutput)
+Strategy: patch `_get_llm` so it returns a fake LLM whose
+`with_structured_output(TriageOutput)` is a real `RunnableLambda` that
+emits a fake TriageOutput. The lambda receives the rendered prompt as
+input so tests can also assert what reached the LLM stage.
 
-Strategy: patch `langchain_anthropic.ChatAnthropic` so that
-`llm.with_structured_output(TriageOutput)` returns a real `RunnableLambda`
-that emits a fake TriageOutput. The lambda receives the rendered prompt as
-input, so we can also assert what variables were passed in.
+Patching `_get_llm` (not the provider classes) means these tests work
+regardless of LLM_PROVIDER — anthropic, gemini, or anything else.
 """
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain_core.runnables import RunnableLambda
 
-from app.services.llm_service import TriageOutput, classify_with_llm
+from app.services.llm_service import TriageOutput, classify_with_llm, _get_llm
 
 
 def _fake_output(
@@ -31,11 +34,10 @@ def _fake_output(
     )
 
 
-def _patch_chat_anthropic(mock_cls, output: TriageOutput, capture: list | None = None):
-    """Wire up mock_cls so chain `_PROMPT | llm.with_structured_output(...)` returns `output`.
+def _patch_llm(mock_get_llm, output: TriageOutput, capture: list | None = None):
+    """Make _get_llm return a fake whose chain emits `output`.
 
-    If `capture` is provided, each invocation of the lambda appends the rendered
-    prompt to it so tests can inspect what reached the LLM stage.
+    If `capture` is provided, each invocation appends the rendered prompt.
     """
     def _lambda(prompt_value):
         if capture is not None:
@@ -44,13 +46,17 @@ def _patch_chat_anthropic(mock_cls, output: TriageOutput, capture: list | None =
 
     mock_llm = MagicMock()
     mock_llm.with_structured_output.return_value = RunnableLambda(_lambda)
-    mock_cls.return_value = mock_llm
+    mock_get_llm.return_value = mock_llm
     return mock_llm
 
 
-@patch("app.services.llm_service.ChatAnthropic")
-def test_classify_returns_triage_result(mock_cls):
-    _patch_chat_anthropic(mock_cls, _fake_output(
+# ---------------------------------------------------------------------------
+# Core classification tests
+# ---------------------------------------------------------------------------
+
+@patch("app.services.llm_service._get_llm")
+def test_classify_returns_triage_result(mock_get_llm):
+    _patch_llm(mock_get_llm, _fake_output(
         category="Bug", priority="High", labels=["bug", "priority-high"], reason="Crash in prod",
     ))
 
@@ -64,24 +70,23 @@ def test_classify_returns_triage_result(mock_cls):
     assert result.issue_number == 42
 
 
-@patch("app.services.llm_service.ChatAnthropic")
-def test_classify_renders_title_and_body_into_prompt(mock_cls):
+@patch("app.services.llm_service._get_llm")
+def test_classify_renders_title_and_body_into_prompt(mock_get_llm):
     captured: list = []
-    _patch_chat_anthropic(mock_cls, _fake_output(), capture=captured)
+    _patch_llm(mock_get_llm, _fake_output(), capture=captured)
 
     classify_with_llm("owner/repo", 1, "My title", "My body", api_key="fake")
 
-    # captured[0] is the rendered ChatPromptValue. Stringifying gives the messages.
     rendered = str(captured[0])
     assert "My title" in rendered
     assert "My body" in rendered
     assert "owner/repo" in rendered
 
 
-@patch("app.services.llm_service.ChatAnthropic")
-def test_classify_includes_context_section(mock_cls):
+@patch("app.services.llm_service._get_llm")
+def test_classify_includes_context_section(mock_get_llm):
     captured: list = []
-    _patch_chat_anthropic(mock_cls, _fake_output(), capture=captured)
+    _patch_llm(mock_get_llm, _fake_output(), capture=captured)
 
     classify_with_llm("owner/repo", 1, "title", "body",
                      context="some retrieved doc", api_key="fake")
@@ -90,9 +95,9 @@ def test_classify_includes_context_section(mock_cls):
     assert "some retrieved doc" in rendered
 
 
-@patch("app.services.llm_service.ChatAnthropic")
-def test_classify_feature_request(mock_cls):
-    _patch_chat_anthropic(mock_cls, _fake_output(
+@patch("app.services.llm_service._get_llm")
+def test_classify_feature_request(mock_get_llm):
+    _patch_llm(mock_get_llm, _fake_output(
         category="Feature Request", priority="Low",
         labels=["feature-request", "priority-low"],
     ))
@@ -103,14 +108,49 @@ def test_classify_feature_request(mock_cls):
     assert result.priority == "Low"
 
 
-@patch("app.services.llm_service.ChatAnthropic")
-def test_classify_propagates_api_error(mock_cls):
+@patch("app.services.llm_service._get_llm")
+def test_classify_propagates_api_error(mock_get_llm):
     def _raise(_):
         raise Exception("API unavailable")
 
     mock_llm = MagicMock()
     mock_llm.with_structured_output.return_value = RunnableLambda(_raise)
-    mock_cls.return_value = mock_llm
+    mock_get_llm.return_value = mock_llm
 
     with pytest.raises(Exception, match="API unavailable"):
         classify_with_llm("owner/repo", 1, "title", "body", api_key="fake")
+
+
+# ---------------------------------------------------------------------------
+# Provider selection tests (_get_llm)
+# ---------------------------------------------------------------------------
+
+class TestProviderSelection:
+    """Tests for the LLM_PROVIDER env var switching between providers."""
+
+    def test_default_provider_is_anthropic(self, monkeypatch):
+        monkeypatch.delenv("LLM_PROVIDER", raising=False)
+        llm = _get_llm(api_key="fake")
+        # ChatAnthropic instances have a 'model' attribute
+        assert "claude" in str(llm.model).lower()
+
+    def test_anthropic_provider_explicit(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        llm = _get_llm(api_key="fake")
+        assert "claude" in str(llm.model).lower()
+
+    def test_gemini_provider(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "gemini")
+        llm = _get_llm(api_key="fake")
+        # ChatGoogleGenerativeAI has a 'model' attribute too
+        assert "gemini" in str(llm.model).lower()
+
+    def test_unknown_provider_raises(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
+        with pytest.raises(ValueError, match="Unknown LLM_PROVIDER"):
+            _get_llm(api_key="fake")
+
+    def test_provider_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "GEMINI")
+        llm = _get_llm(api_key="fake")
+        assert "gemini" in str(llm.model).lower()


### PR DESCRIPTION
Three things stacked on this branch:

**Gemini support.** Added an `LLM_PROVIDER` env var to pick between Claude and Gemini. Also fixed a bug where the LLM gate was hard-coded to `ANTHROPIC_API_KEY`, so anyone configuring Gemini was silently falling through to the keyword fallback.

**Eval suite.** 10 hand-written cases in `tests/eval/cases.yaml`, runner in `run_eval.py`. Ingests the repo's docs, runs each case, scores both the triage decision and which RAG-context keywords were retrieved. Writes timestamped JSON so I can diff two runs.

Why bother: I wanted to refactor the chunking strategy but had no way to tell whether it actually helped. With the suite I can label a run before the change, label one after, and compare per-case.

**Heading-aware doc chunking.** Replaced the 512-char slice with `MarkdownHeaderTextSplitter` + `RecursiveCharacterTextSplitter`. Section boundaries and the heading path are preserved as chunk metadata.

Eval results, deterministic across two runs:

| Case | Before | After | Notes |
| --- | --- | --- | --- |
| `q_json_logging_env_var` | 0.00 | 1.00 | env-var reference table now stays in one chunk |
| `q_feedback_verdicts_meaning` | 1.00 | 0.50 | chunker picked a different chunk for this query |
| Four others | unchanged | unchanged | |

One win on the case I was targeting, one regression I didn't predict. Worth landing because the win is on a structural failure (split table) and the regression is a similarity-ranking shift that more cases or a tuned embedding could address.

### Worth knowing before reviewing

- `tests/conftest.py` clears LLM env vars before every test so the unit suite is deterministic regardless of what's in your local `.env`. Tests that need real LLM behavior mock `_get_llm`.
- `TriageOutput` fields now have defaults. Gemini occasionally returns partial structured outputs and I'd rather degrade than raise `OutputParserException`.
- The eval is NOT in the pytest run — it costs real money. Run with `python -m tests.eval.run_eval --label <whatever>`.
- `README.md` and `docs/project_spec.md` were rewritten to describe what's actually in the codebase, not the original plan.

### Tests

147 unit tests pass. Eval runs end-to-end against Gemini 2.5 Flash. Verified manually against the real API.